### PR TITLE
[FD4-13] feat: schedule page for today's movies and upcoming movies.

### DIFF
--- a/FrontEnd/Models/DailySchedule.cs
+++ b/FrontEnd/Models/DailySchedule.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace FrontEnd.Models
+{
+    public class DailySchedule
+    {
+        public string Date { get; set; }
+        public string DayOfWeek { get; set; }
+        public List<MovieScheduleItem> Movies { get; set; } = new List<MovieScheduleItem>();
+    }
+} 

--- a/FrontEnd/Models/FormatInfo.cs
+++ b/FrontEnd/Models/FormatInfo.cs
@@ -1,0 +1,8 @@
+namespace FrontEnd.Models
+{
+    public class FormatInfo
+    {
+        public string Name { get; set; }
+        public string Description { get; set; }
+    }
+} 

--- a/FrontEnd/Models/MovieSchedule.cs
+++ b/FrontEnd/Models/MovieSchedule.cs
@@ -1,0 +1,7 @@
+using System;
+using System.Collections.Generic;
+
+// This file is kept for backward compatibility
+// All classes have been moved to separate files in their respective folders:
+// - Models folder for data models
+// - Responses folder for API response objects 

--- a/FrontEnd/Models/MovieSchedule.cs
+++ b/FrontEnd/Models/MovieSchedule.cs
@@ -1,7 +1,0 @@
-using System;
-using System.Collections.Generic;
-
-// This file is kept for backward compatibility
-// All classes have been moved to separate files in their respective folders:
-// - Models folder for data models
-// - Responses folder for API response objects 

--- a/FrontEnd/Models/MovieScheduleItem.cs
+++ b/FrontEnd/Models/MovieScheduleItem.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace FrontEnd.Models
+{
+    public class MovieScheduleItem
+    {
+        public int MovieId { get; set; }
+        public string Title { get; set; }
+        public int Duration { get; set; }
+        public List<string> Formats { get; set; } = new List<string>();
+        public string PosterUrl { get; set; }
+        public List<ShowtimeItem> Showtimes { get; set; } = new List<ShowtimeItem>();
+    }
+} 

--- a/FrontEnd/Models/MovieScheduleResponse.cs
+++ b/FrontEnd/Models/MovieScheduleResponse.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace FrontEnd.Models
+{
+    public class MovieScheduleResponse
+    {
+        public List<DailySchedule> Schedule { get; set; } = new List<DailySchedule>();
+    }
+} 

--- a/FrontEnd/Models/Responses/DailyMovieSchedule.cs
+++ b/FrontEnd/Models/Responses/DailyMovieSchedule.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using FrontEnd.Models;
+
+namespace FrontEnd.Models.Responses
+{
+    public class DailyMovieSchedule
+    {
+        public string Date { get; set; }
+        public string DayOfWeek { get; set; }
+        public List<ShowtimeItem> Showtimes { get; set; } = new List<ShowtimeItem>();
+    }
+} 

--- a/FrontEnd/Models/Responses/MovieDetailSchedule.cs
+++ b/FrontEnd/Models/Responses/MovieDetailSchedule.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using FrontEnd.Models;
+
+namespace FrontEnd.Models.Responses
+{
+    public class MovieDetailSchedule
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public int DurationMinutes { get; set; }
+        public string Genre { get; set; }
+        public string AgeRating { get; set; }
+        public string PosterUrl { get; set; }
+        public string BackdropUrl { get; set; }
+        public List<FormatInfo> Formats { get; set; } = new List<FormatInfo>();
+        public List<DailyMovieSchedule> Schedule { get; set; } = new List<DailyMovieSchedule>();
+    }
+} 

--- a/FrontEnd/Models/ShowtimeItem.cs
+++ b/FrontEnd/Models/ShowtimeItem.cs
@@ -1,0 +1,17 @@
+namespace FrontEnd.Models
+{
+    public class ShowtimeItem
+    {
+        public int Id { get; set; }
+        public int HallId { get; set; }
+        public string HallName { get; set; }
+        public string StartTime { get; set; }
+        public string EndTime { get; set; }
+        public string Format { get; set; }
+        public decimal Price { get; set; }
+        public int TotalSeats { get; set; }
+        public int AvailableSeats { get; set; }
+        public bool IsAlmostFull { get; set; }
+        public bool IsSoldOut { get; set; }
+    }
+} 

--- a/FrontEnd/Pages/AlmostSoldOutTest.razor
+++ b/FrontEnd/Pages/AlmostSoldOutTest.razor
@@ -1,0 +1,325 @@
+@page "/almost-sold-out-test"
+@using FrontEnd.Models
+@using System.Globalization
+@inject HttpClient Http
+@inject IJSRuntime JS
+@inject NavigationManager NavigationManager
+
+<PageTitle>Almost Sold Out Test - Cinemagia</PageTitle>
+
+<link href="css/schedule.css" rel="stylesheet" />
+<link href="css/home_navbar.css" rel="stylesheet" />
+
+<div class="cinema-container">
+    <!-- Navigation Bar -->
+    <nav class="homepage-navbar">
+        <div class="nav-left-group">
+            <div class="logo-container">
+                <a href="/">
+                    <img src="Cinemagia_logo.jpg" alt="Logo" class="navbar-logo">
+                </a>
+            </div>
+            
+            <ul class="nav-links">
+                <li><a href="/">Home</a></li>
+                <li><a href="/schedule">Film Schedule</a></li>
+                <li><a href="/almost-sold-out-test" class="active">Almost Sold Out Test</a></li>
+            </ul>
+        </div>
+        
+        <div class="nav-secondary">
+            <div class="search-icon">🔍</div>
+            <div class="account-icon">👤</div>
+            <div class="language-selector">EN</div>
+        </div>
+    </nav>
+
+    <div class="content-with-header-space">
+        <div class="schedule-container">
+            <h1 class="page-title">Almost Sold Out Test</h1>
+            
+            @if (isLoading)
+            {
+                <div class="loading-container">
+                    <div class="spinner-border" role="status"></div>
+                    <p>Setting up test presentations...</p>
+                </div>
+            }
+            else if (testPresentations != null && testPresentations.Any())
+            {
+                <div class="alert alert-info">
+                    <strong>Test Data Created</strong>
+                    <p>These presentations have been created for today (@testDate). You can view them in the regular schedule page too.</p>
+                </div>
+                
+                <div class="mb-4 test-actions">
+                    <button class="btn-primary" @onclick="RefreshTestData">Refresh Test Data</button>
+                    <a href="/schedule" class="btn-secondary">View in Schedule</a>
+                </div>
+                
+                <div class="test-presentations">
+                    <h2>Test Presentations</h2>
+                    <div class="legend">
+                        <div class="legend-item almost-sold-out">
+                            <span class="indicator"></span>
+                            <span>Almost Sold Out (&lt;15% seats available)</span>
+                        </div>
+                        <div class="legend-item moderately-full">
+                            <span class="indicator"></span>
+                            <span>Moderately Full (30-50% seats available)</span>
+                        </div>
+                        <div class="legend-item plenty-available">
+                            <span class="indicator"></span>
+                            <span>Plenty Available (70-90% seats available)</span>
+                        </div>
+                    </div>
+
+                    <table class="test-presentations-table">
+                        <thead>
+                            <tr>
+                                <th>Movie</th>
+                                <th>Hall</th>
+                                <th>Start Time</th>
+                                <th>Format</th>
+                                <th>Available / Total</th>
+                                <th>% Sold</th>
+                                <th>Status</th>
+                                <th>Action</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var presentation in testPresentations)
+                            {
+                                <tr class="@GetAvailabilityClass(presentation.SoldOutPercentage)">
+                                    <td>@presentation.MovieTitle</td>
+                                    <td>@presentation.HallName</td>
+                                    <td>@presentation.StartTime</td>
+                                    <td>@presentation.Format</td>
+                                    <td>@presentation.AvailableSeats / @presentation.TotalSeats</td>
+                                    <td>@presentation.SoldOutPercentage%</td>
+                                    <td>
+                                        @if (presentation.AlmostSoldOut)
+                                        {
+                                            <span class="almost-sold-out-badge">Almost Sold Out!</span>
+                                        }
+                                        else
+                                        {
+                                            <span>Available</span>
+                                        }
+                                    </td>
+                                    <td>
+                                        <a href="/seat-selector/@presentation.PresentationId" class="btn-view">View Seats</a>
+                                    </td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+            else
+            {
+                <div class="error-message">
+                    <p>@errorMessage</p>
+                    <button class="btn-primary" @onclick="RefreshTestData">Try Again</button>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+<style>
+    .test-actions {
+        display: flex;
+        gap: 1rem;
+        margin-bottom: 2rem;
+    }
+    
+    .alert {
+        padding: 1rem;
+        border-radius: 4px;
+        margin-bottom: 1rem;
+    }
+    
+    .alert-info {
+        background-color: #e8f0fe;
+        border: 1px solid #4285f4;
+        color: #174ea6;
+    }
+    
+    .alert strong {
+        display: block;
+        margin-bottom: 0.5rem;
+    }
+    
+    .btn-primary, .btn-secondary, .btn-view {
+        padding: 0.5rem 1rem;
+        border-radius: 4px;
+        text-decoration: none;
+        display: inline-block;
+        cursor: pointer;
+        font-weight: 500;
+    }
+    
+    .btn-primary {
+        background-color: #1a73e8;
+        color: white;
+        border: none;
+    }
+    
+    .btn-secondary {
+        background-color: #f1f3f4;
+        color: #202124;
+        border: 1px solid #dadce0;
+    }
+    
+    .btn-view {
+        background-color: #f8f9fa;
+        color: #1a73e8;
+        border: 1px solid #dadce0;
+        font-size: 0.85rem;
+    }
+    
+    .legend {
+        display: flex;
+        margin-bottom: 1rem;
+        gap: 1.5rem;
+    }
+    
+    .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+    
+    .legend-item .indicator {
+        width: 1rem;
+        height: 1rem;
+        border-radius: 50%;
+    }
+    
+    .almost-sold-out .indicator {
+        background-color: #f44336;
+    }
+    
+    .moderately-full .indicator {
+        background-color: #ff9800;
+    }
+    
+    .plenty-available .indicator {
+        background-color: #4caf50;
+    }
+    
+    .test-presentations-table {
+        width: 100%;
+        border-collapse: collapse;
+        margin-top: 1rem;
+    }
+    
+    .test-presentations-table th {
+        background-color: #f8f9fa;
+        text-align: left;
+        padding: 0.75rem;
+        border-bottom: 2px solid #dadce0;
+    }
+    
+    .test-presentations-table td {
+        padding: 0.75rem;
+        border-bottom: 1px solid #dadce0;
+    }
+    
+    .test-presentations-table tr.row-almost-sold-out {
+        background-color: rgba(244, 67, 54, 0.1);
+    }
+    
+    .test-presentations-table tr.row-moderately-full {
+        background-color: rgba(255, 152, 0, 0.1);
+    }
+    
+    .test-presentations-table tr.row-plenty-available {
+        background-color: rgba(76, 175, 80, 0.1);
+    }
+    
+    .almost-sold-out-badge {
+        display: inline-block;
+        padding: 0.25rem 0.5rem;
+        background-color: #f44336;
+        color: white;
+        border-radius: 4px;
+        font-size: 0.85rem;
+        font-weight: 500;
+    }
+</style>
+
+@code {
+    private List<TestPresentation> testPresentations = new List<TestPresentation>();
+    private bool isLoading = true;
+    private string errorMessage = "No test data available. Try refreshing.";
+    private string testDate = DateTime.Today.ToString("yyyy-MM-dd");
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RefreshTestData();
+    }
+
+    private async Task RefreshTestData()
+    {
+        isLoading = true;
+        StateHasChanged();
+        
+        try
+        {
+            var response = await Http.GetFromJsonAsync<TestResponse>("api/tickets/test/almost-sold-out-test");
+            
+            if (response != null)
+            {
+                testPresentations = response.Presentations;
+                testDate = response.TestDate;
+                errorMessage = "";
+            }
+            else
+            {
+                errorMessage = "Failed to get test data from the server.";
+                testPresentations = new List<TestPresentation>();
+            }
+        }
+        catch (Exception ex)
+        {
+            errorMessage = $"Error: {ex.Message}";
+            testPresentations = new List<TestPresentation>();
+        }
+        
+        isLoading = false;
+        StateHasChanged();
+    }
+    
+    private string GetAvailabilityClass(int soldOutPercentage)
+    {
+        if (soldOutPercentage >= 85) // Almost sold out
+            return "row-almost-sold-out";
+        else if (soldOutPercentage >= 50 && soldOutPercentage < 70) // Moderately full
+            return "row-moderately-full";
+        else // Plenty available
+            return "row-plenty-available";
+    }
+    
+    // Define classes for deserialization
+    public class TestResponse
+    {
+        public string TestDate { get; set; }
+        public string Note { get; set; }
+        public List<TestPresentation> Presentations { get; set; }
+    }
+    
+    public class TestPresentation
+    {
+        public int PresentationId { get; set; }
+        public string HallName { get; set; }
+        public string MovieTitle { get; set; }
+        public string StartTime { get; set; }
+        public string Format { get; set; }
+        public int TotalSeats { get; set; }
+        public int AvailableSeats { get; set; }
+        public int SoldOutPercentage { get; set; }
+        public bool AlmostSoldOut { get; set; }
+    }
+} 

--- a/FrontEnd/Pages/Home.razor
+++ b/FrontEnd/Pages/Home.razor
@@ -25,6 +25,7 @@
             
             <ul class="nav-links @(isMobileMenuOpen ? "active" : "")">
                 <li><a href="#film-posters">Movies</a></li>
+                <li><a href="/schedule">Schedule</a></li>
             </ul>
         </div>
         

--- a/FrontEnd/Pages/Schedule.razor
+++ b/FrontEnd/Pages/Schedule.razor
@@ -1,0 +1,551 @@
+@page "/schedule"
+@using FrontEnd.Models
+@using FrontEnd.Models.Responses
+@using System.Globalization
+@inject HttpClient Http
+@inject IJSRuntime JS
+
+<PageTitle>Film Schedule - Cinemagia</PageTitle>
+
+<link href="css/schedule.css" rel="stylesheet" />
+<link href="css/home_navbar.css" rel="stylesheet" />
+
+<div class="cinema-container">
+    <!-- Navigation Bar -->
+    <nav class="homepage-navbar">
+        <div class="nav-left-group">
+            <div class="logo-container">
+                <a href="/">
+                    <img src="Cinemagia_logo.jpg" alt="Logo" class="navbar-logo">
+                </a>
+            </div>
+            
+            <ul class="nav-links">
+                <li><a href="/">Home</a></li>
+                <li><a href="/schedule" class="active">Film Schedule</a></li>
+            </ul>
+        </div>
+        
+        <div class="nav-secondary">
+            <div class="search-icon">🔍</div>
+            <div class="account-icon">👤</div>
+            <div class="language-selector">EN</div>
+        </div>
+    </nav>
+
+    <div class="content-with-header-space">
+        <div class="schedule-container">
+            <h1 class="page-title">Film Schedule</h1>
+            
+            <!-- Filters Section -->
+            <div class="filters-section">
+                <div class="filter-item">
+                    <label for="formatFilter">Format:</label>
+                    <select id="formatFilter" value="@selectedFormat" @onchange="@((e) => FormatChanged(e.Value.ToString()))">
+                        <option value="">All Formats</option>
+                        @foreach (var format in availableFormats)
+                        {
+                            bool isCurrentlySelected = string.Equals(format, selectedFormat, StringComparison.OrdinalIgnoreCase);
+                            bool isAvailable = IsFormatAvailableOnSelectedDate(format);
+                            bool showUnavailabilityIndicator = !isAvailable && !isCurrentlySelected;
+                            
+                            <option value="@format" selected="@isCurrentlySelected">
+                                @format @(showUnavailabilityIndicator ? "(none on this day)" : "")
+                            </option>
+                        }
+                    </select>
+                </div>
+                
+                <div class="filter-item">
+                    <label for="sortBy">Sort by:</label>
+                    <select id="sortBy" value="@sortBy" @onchange="@((e) => SortChanged(e.Value.ToString()))">
+                        <option value="time">Time (Earliest First)</option>
+                        <option value="time_desc">Time (Latest First)</option>
+                        <option value="popularity">Popularity (Most Popular First)</option>
+                        <option value="popularity_asc">Popularity (Least Popular First)</option>
+                    </select>
+                </div>
+                
+                <button class="btn-reset-filters" @onclick="ResetFilters">Reset Filters</button>
+            </div>
+            
+            <!-- Date Navigation -->
+            <div class="dates-nav">
+                @foreach (var date in dateRange)
+                {
+                    <button class="date-btn @(date.Date == selectedDate.Date ? "active" : "")" @onclick="() => ChangeDate(date)">
+                        <span class="date-day">@date.ToString("ddd", CultureInfo.InvariantCulture)</span>
+                        <span class="date-num">@date.Day</span>
+                        <span class="date-month">@date.ToString("MMM", CultureInfo.InvariantCulture)</span>
+                    </button>
+                }
+            </div>
+            
+            <!-- Schedule Content -->
+            @if (isLoading)
+            {
+                <div class="loading-container">
+                    <div class="spinner-border" role="status"></div>
+                    <p>Loading schedule...</p>
+                </div>
+            }
+            else if (schedule != null && schedule.Any())
+            {
+                <div class="schedule-date-heading">
+                    <h2>@selectedDate.ToString("dddd, MMMM d", CultureInfo.InvariantCulture)</h2>
+                </div>
+                
+                <div class="schedule-content">
+                    @{
+                        var selectedDaySchedule = schedule.FirstOrDefault(s => s.Date == selectedDate.ToString("yyyy-MM-dd"));
+                        var moviesToShow = selectedDaySchedule?.Movies ?? Enumerable.Empty<MovieScheduleItem>();
+                    }
+                    
+                    @if (!moviesToShow.Any() && !string.IsNullOrEmpty(selectedFormat))
+                    {
+                        <div class="no-schedule-message">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="message-icon"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"></path><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"></path><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"></path><line x1="2" y1="2" x2="22" y2="22"></line></svg>
+                            <p>No movies available in @selectedFormat format on @selectedDate.ToString("dddd, MMMM d").</p>
+                            <div class="message-actions">
+                                <button class="btn-inline" @onclick="ResetFilters">Reset filters</button> or select another date.
+                            </div>
+                        </div>
+                    }
+                    else if (!moviesToShow.Any())
+                    {
+                        <div class="no-schedule-message">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="message-icon"><path d="M9.88 9.88a3 3 0 1 0 4.24 4.24"></path><path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68"></path><path d="M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61"></path><line x1="2" y1="2" x2="22" y2="22"></line></svg>
+                            <p>No movies scheduled for @selectedDate.ToString("dddd, MMMM d").</p>
+                            <div class="message-actions">
+                                Please select another date.
+                            </div>
+                        </div>
+                    }
+                    else
+                    {
+                        @foreach (var movie in moviesToShow)
+                        {
+                            <div class="movie-schedule-item">
+                                <div class="movie-info">
+                                    <a href="/film/@movie.MovieId" class="movie-poster-link">
+                                        <img src="@movie.PosterUrl" alt="@movie.Title" class="movie-poster">
+                                    </a>
+                                    <div class="movie-details">
+                                        <h3 class="movie-title">
+                                            <a href="/film/@movie.MovieId">@movie.Title</a>
+                                        </h3>
+                                        <div class="movie-meta">
+                                            <span class="movie-duration">@movie.Duration min</span>
+                                            <div class="format-badges">
+                                                @foreach (var format in movie.Formats)
+                                                {
+                                                    <span class="format-badge">@format</span>
+                                                }
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                
+                                <div class="showtimes-container">
+                                    <h4>Available Showtimes:</h4>
+                                    <div class="showtimes-list">
+                                        @if (movie.Showtimes != null && movie.Showtimes.Any())
+                                        {
+                                            @foreach (var showtime in movie.Showtimes)
+                                            {
+                                                @if (showtime.IsSoldOut)
+                                                {
+                                                    <div class="showtime-btn sold-out" title="Sold out!">
+                                                        <span class="time">@showtime.StartTime</span>
+                                                        <span class="hall">@showtime.HallName</span>
+                                                        <span class="format">@showtime.Format</span>
+                                                        <span class="availability-indicator sold-out-indicator">Sold out</span>
+                                                        @{
+                                                            // Log for debugging
+                                                            Console.WriteLine($"Sold out showtime: ID {showtime.Id}, Time: {showtime.StartTime}, Available: {showtime.AvailableSeats}/{showtime.TotalSeats}");
+                                                        }
+                                                    </div>
+                                                }
+                                                else
+                                                {
+                                                    <a href="/seat-selector/@showtime.Id" 
+                                                       class="showtime-btn @(showtime.IsAlmostFull ? "almost-full" : "")" 
+                                                       title="@(showtime.IsAlmostFull ? "Almost sold out!" : "")">
+                                                        <span class="time">@showtime.StartTime</span>
+                                                        <span class="hall">@showtime.HallName</span>
+                                                        <span class="format">@showtime.Format</span>
+                                                        @if (showtime.IsAlmostFull)
+                                                        {
+                                                            <span class="availability-indicator">Almost sold out</span>
+                                                        }
+                                                        @{
+                                                            // Log for debugging
+                                                            if (showtime.IsAlmostFull)
+                                                            {
+                                                                Console.WriteLine($"Almost full showtime: ID {showtime.Id}, Time: {showtime.StartTime}, Available: {showtime.AvailableSeats}/{showtime.TotalSeats}");
+                                                            }
+                                                        }
+                                                    </a>
+                                                }
+                                            }
+                                        }
+                                        else
+                                        {
+                                            <div class="no-showtimes">No showtimes available</div>
+                                        }
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    }
+                </div>
+            }
+            else
+            {
+                <div class="no-schedule-message">
+                    <p>No movies scheduled for this date. Please try another date or check back later.</p>
+                </div>
+            }
+        </div>
+    </div>
+</div>
+
+@code {
+    private List<DailySchedule> schedule = new List<DailySchedule>();
+    private List<DateTime> dateRange = new List<DateTime>();
+    private DateTime selectedDate = DateTime.Today;
+    private bool isLoading = true;
+    private string selectedFormat = "";
+    private string sortBy = "time";
+    private List<string> availableFormats = new List<string>();
+    private List<string> allAvailableFormats = new List<string>();  // Store all formats regardless of current filter
+    
+    // Dictionary to track which formats are available on each date
+    // Key: date string (yyyy-MM-dd), Value: list of formats available on that date
+    private Dictionary<string, HashSet<string>> formatAvailabilityByDate = new Dictionary<string, HashSet<string>>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        // Initialize date range for next 7 days
+        dateRange = Enumerable.Range(0, 7)
+            .Select(i => DateTime.Today.AddDays(i))
+            .ToList();
+            
+        await LoadSchedule();
+    }
+
+    private async Task LoadSchedule()
+    {
+        isLoading = true;
+        
+        try
+        {
+            // Store original case of selectedFormat before the API call
+            string originalSelectedFormat = selectedFormat;
+            Console.WriteLine($"Original format: {originalSelectedFormat}");
+            
+            // Build the API URL with query parameters
+            string apiUrl = $"api/presentations/schedule?startDate={DateTime.Today:yyyy-MM-dd}&endDate={DateTime.Today.AddDays(6):yyyy-MM-dd}";
+            
+            if (!string.IsNullOrEmpty(selectedFormat))
+            {
+                apiUrl += $"&format={Uri.EscapeDataString(selectedFormat)}";
+            }
+            
+            // The server sorting isn't working well, so we'll only send time/popularity to the server
+            // and do the rest of the sorting client-side
+            string serverSortBy = sortBy;
+            if (sortBy == "time_desc" || sortBy == "popularity_asc")
+            {
+                serverSortBy = sortBy.Split('_')[0]; // Extract 'time' or 'popularity'
+            }
+            
+            apiUrl += $"&sortBy={Uri.EscapeDataString(serverSortBy)}";
+            
+            Console.WriteLine($"API URL: {apiUrl}");
+            
+            // Fetch the schedule from the API
+            var response = await Http.GetFromJsonAsync<List<DailySchedule>>(apiUrl);
+            
+            if (response != null)
+            {
+                schedule = response;
+                
+                // Apply our client-side sorting to get more meaningful results
+                ApplyClientSideSorting();
+                
+                // Extract formats from the current schedule
+                var currentFormats = schedule
+                    .SelectMany(d => d.Movies)
+                    .SelectMany(m => m.Formats)
+                    .Distinct()
+                    .OrderBy(f => f)
+                    .ToList();
+                
+                // For the first load or when resetting filters, update all available formats
+                if (string.IsNullOrEmpty(originalSelectedFormat))
+                {
+                    allAvailableFormats = currentFormats;
+                    
+                    // When loading all formats, update our format availability tracking
+                    UpdateFormatAvailabilityTracking();
+                }
+                // Otherwise, merge any new formats into our master list
+                else
+                {
+                    foreach (var format in currentFormats)
+                    {
+                        if (!allAvailableFormats.Contains(format, StringComparer.OrdinalIgnoreCase))
+                        {
+                            allAvailableFormats.Add(format);
+                        }
+                    }
+                    // Keep the list sorted
+                    allAvailableFormats = allAvailableFormats.OrderBy(f => f).ToList();
+                }
+                
+                // Use allAvailableFormats for the dropdown
+                availableFormats = allAvailableFormats;
+                
+                Console.WriteLine($"Available formats: {string.Join(", ", availableFormats)}");
+                
+                // Restore the original format selection if it's still in the list (case-insensitive)
+                if (!string.IsNullOrEmpty(originalSelectedFormat))
+                {
+                    // Check if the original format exists in the format list (case-insensitive)
+                    var matchingFormat = availableFormats.FirstOrDefault(f => 
+                        string.Equals(f, originalSelectedFormat, StringComparison.OrdinalIgnoreCase));
+                    
+                    if (matchingFormat != null)
+                    {
+                        Console.WriteLine($"Found matching format: {matchingFormat}");
+                        // Preserve the original selection by setting it to the matching format
+                        selectedFormat = matchingFormat;
+                    }
+                    else
+                    {
+                        Console.WriteLine("No matching format found");
+                    }
+                }
+                
+                Console.WriteLine($"Final selected format: {selectedFormat}");
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error loading schedule: {ex.Message}");
+            schedule = new List<DailySchedule>();
+        }
+        
+        isLoading = false;
+        StateHasChanged();
+    }
+
+    private async Task ChangeDate(DateTime date)
+    {
+        // Update selected date
+        selectedDate = date;
+        
+        Console.WriteLine($"Changing date to: {selectedDate:yyyy-MM-dd}");
+        Console.WriteLine($"Formats available on this date: {string.Join(", ", GetFormatsAvailableOnDate(selectedDate))}");
+        
+        // If a format is selected, we need to reload the data for the selected date with that format
+        if (!string.IsNullOrEmpty(selectedFormat))
+        {
+            bool isSelectedFormatAvailable = IsFormatAvailableOnSelectedDate(selectedFormat);
+            Console.WriteLine($"Selected format {selectedFormat} available on this date: {isSelectedFormatAvailable}");
+            
+            // Reload the data with the current format filter and new date
+            await LoadSchedule();
+        }
+        else
+        {
+            // When no format is selected, we just need to refresh the UI
+            // as we already have all the data for all dates
+            StateHasChanged();
+        }
+    }
+
+    // Helper method to get the list of formats available on a specific date
+    private List<string> GetFormatsAvailableOnDate(DateTime date)
+    {
+        string dateKey = date.ToString("yyyy-MM-dd");
+        
+        if (formatAvailabilityByDate.ContainsKey(dateKey))
+        {
+            return formatAvailabilityByDate[dateKey].ToList();
+        }
+        
+        return new List<string>();
+    }
+
+    private async Task SortChanged(string newSort)
+    {
+        Console.WriteLine($"Sort changed to: {newSort}");
+        sortBy = newSort;
+        await LoadSchedule();
+    }
+
+    private async Task ResetFilters()
+    {
+        // Reset the format selection
+        selectedFormat = string.Empty;
+        
+        // Reload the schedule without format filter
+        await LoadSchedule();
+        
+        // Force UI update
+        StateHasChanged();
+    }
+
+    private async Task FormatChanged(string newFormat)
+    {
+        Console.WriteLine($"Format changed to: {newFormat}");
+        selectedFormat = newFormat;
+        await LoadSchedule();
+    }
+
+    // Manually sort schedules based on our own sorting logic
+    private void ApplyClientSideSorting()
+    {
+        // Only apply client-side sorting if we have a schedule
+        if (schedule == null || !schedule.Any())
+            return;
+            
+        foreach (var day in schedule)
+        {
+            if (day.Movies == null)
+                continue;
+                
+            // Apply sorting to movies and their showtimes
+            switch (sortBy)
+            {
+                case "time":
+                    // Sort showtimes for each movie by start time (ascending)
+                    foreach (var movie in day.Movies)
+                    {
+                        if (movie.Showtimes != null)
+                        {
+                            movie.Showtimes = movie.Showtimes
+                                .OrderBy(s => TimeSpan.Parse(s.StartTime))
+                                .ToList();
+                        }
+                    }
+                    break;
+                    
+                case "time_desc":
+                    // Sort showtimes for each movie by start time (descending)
+                    foreach (var movie in day.Movies)
+                    {
+                        if (movie.Showtimes != null)
+                        {
+                            movie.Showtimes = movie.Showtimes
+                                .OrderByDescending(s => TimeSpan.Parse(s.StartTime))
+                                .ToList();
+                        }
+                    }
+                    break;
+                    
+                case "popularity":
+                    // Sort movies by the sum of how full their showtimes are (descending)
+                    day.Movies = day.Movies
+                        .OrderByDescending(m => 
+                            m.Showtimes != null 
+                                ? m.Showtimes.Sum(s => s.TotalSeats - s.AvailableSeats)
+                                : 0)
+                        .ToList();
+                    break;
+                    
+                case "popularity_asc":
+                    // Sort movies by the sum of how full their showtimes are (ascending)
+                    day.Movies = day.Movies
+                        .OrderBy(m => 
+                            m.Showtimes != null 
+                                ? m.Showtimes.Sum(s => s.TotalSeats - s.AvailableSeats)
+                                : 0)
+                        .ToList();
+                    break;
+            }
+        }
+    }
+
+    private bool IsFormatInCurrentResults(string format)
+    {
+        // If no schedule data is available, we can't determine format availability
+        if (schedule == null || !schedule.Any())
+        {
+            return false;
+        }
+
+        // Get the daily schedule for the selected date
+        var selectedDaySchedule = schedule.FirstOrDefault(s => s.Date == selectedDate.ToString("yyyy-MM-dd"));
+        
+        // If there's no schedule for the selected day or no movies, format is not available
+        if (selectedDaySchedule == null || !selectedDaySchedule.Movies.Any())
+        {
+            return false;
+        }
+
+        // Check if any movie has a showtime with this format on the selected date
+        return selectedDaySchedule.Movies.Any(movie => 
+            movie.Showtimes != null && 
+            movie.Showtimes.Any(showtime => 
+                string.Equals(showtime.Format, format, StringComparison.OrdinalIgnoreCase))
+        );
+    }
+
+    // New method to update our tracking of which formats are available on each date
+    private void UpdateFormatAvailabilityTracking()
+    {
+        // Clear existing tracking data if resetting filters
+        if (string.IsNullOrEmpty(selectedFormat))
+        {
+            formatAvailabilityByDate.Clear();
+        }
+
+        // For each date in the schedule
+        foreach (var day in schedule)
+        {
+            string dateKey = day.Date;
+            
+            // Initialize the format set for this date if it doesn't exist
+            if (!formatAvailabilityByDate.ContainsKey(dateKey))
+            {
+                formatAvailabilityByDate[dateKey] = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            }
+            
+            // Add all formats that have showtimes on this date
+            foreach (var movie in day.Movies)
+            {
+                if (movie.Showtimes != null)
+                {
+                    foreach (var showtime in movie.Showtimes)
+                    {
+                        formatAvailabilityByDate[dateKey].Add(showtime.Format);
+                    }
+                }
+            }
+        }
+    }
+
+    // Updated method to check format availability based on our tracking
+    private bool IsFormatAvailableOnSelectedDate(string format)
+    {
+        string dateKey = selectedDate.ToString("yyyy-MM-dd");
+        
+        // If we're filtering by this format, it's obviously "available"
+        if (string.Equals(format, selectedFormat, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        
+        // If we have tracking data for this date, use it
+        if (formatAvailabilityByDate.ContainsKey(dateKey))
+        {
+            return formatAvailabilityByDate[dateKey].Contains(format);
+        }
+        
+        // Otherwise, fall back to the current results (which might be filtered)
+        return IsFormatInCurrentResults(format);
+    }
+} 

--- a/FrontEnd/Pages/SeatSelector.razor
+++ b/FrontEnd/Pages/SeatSelector.razor
@@ -1089,57 +1089,54 @@
     {
         try
         {
-    string? tokenToCancel = orderToken ?? pendingGroupOrder?.OrderToken;
-    if (tokenToCancel != null)
-    {
-        // Hide any open modals
-        showSeatSelectionModal = false;
-        await JSRuntime.InvokeVoidAsync("hideModal", "seatingOptionsModal");
-        await JSRuntime.InvokeVoidAsync("hideModal", "singleOptionConfirmModal");
-        await JSRuntime.InvokeVoidAsync("hideModal", "numpadModal");
+            string? tokenToCancel = orderToken ?? pendingGroupOrder?.OrderToken;
+            if (tokenToCancel != null)
+            {
+                // Hide any open modals
+                showSeatSelectionModal = false;
+                await JSRuntime.InvokeVoidAsync("hideModal", "seatingOptionsModal");
+                await JSRuntime.InvokeVoidAsync("hideModal", "singleOptionConfirmModal");
+                await JSRuntime.InvokeVoidAsync("hideModal", "numpadModal");
 
-        // Call the API to cancel the order
-        var response = await Http.PostAsync($"api/tickets/orders/{tokenToCancel}/cancel", null);
+                // Call the API to cancel the order
+                var response = await Http.PostAsync($"api/tickets/orders/{tokenToCancel}/cancel", null);
 
-        if (response.IsSuccessStatusCode)
-        {
-            // Stop both timers
-            expirationTimer.Stop();
-            validationTimer.Stop();
-            orderExpirationTime = null;
+                if (response.IsSuccessStatusCode)
+                {
+                    // Stop both timers
+                    expirationTimer.Stop();
+                    validationTimer.Stop();
+                    orderExpirationTime = null;
 
-            // Clear local state
-            orderToken = null;
-            pendingGroupOrder = null;
-            selectedSeats.Clear();
-            availableOptions = null;
-            selectedOption = null;
-            SetMessage("Order cancelled successfully.");
-            numpadPinConfirmed = false;
-            NumpadClearInput();
+                    // Clear local state
+                    orderToken = null;
+                    pendingGroupOrder = null;
+                    selectedSeats.Clear();
+                    availableOptions = null;
+                    selectedOption = null;
+                    SetMessage("Order cancelled successfully.");
+                    numpadPinConfirmed = false;
+                    NumpadClearInput();
 
-            // Refresh the seats to show updated availability
-            await LoadSeats();
-
-            // Go back to the seat selection modal
-            showSeatSelectionModal = true;
-        }
-        else
-        {
-            var error = await response.Content.ReadAsStringAsync();
-            SetMessage($"Failed to cancel order: {error}");
-        }
-    }
-    else
-    {
-        // If there's no active order yet, just show the modal again
-        showSeatSelectionModal = true;
-    }
+                    // Navigate back to the previous page using our custom navigateBack function
+                    await JSRuntime.InvokeVoidAsync("navigateBack");
+                }
+                else
+                {
+                    var error = await response.Content.ReadAsStringAsync();
+                    SetMessage($"Failed to cancel order: {error}");
+                }
+            }
+            else
+            {
+                // If there's no active order yet, just navigate back to the previous page
+                await JSRuntime.InvokeVoidAsync("navigateBack");
+            }
         }
         catch (Exception ex)
         {
-    SetMessage($"Error cancelling order: {ex.Message}");
-    Console.WriteLine($"Error cancelling order: {ex}");
+            SetMessage($"Error cancelling order: {ex.Message}");
+            Console.WriteLine($"Error cancelling order: {ex}");
         }
     }
 

--- a/FrontEnd/Responses/DailyMovieSchedule.cs
+++ b/FrontEnd/Responses/DailyMovieSchedule.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using FrontEnd.Models;
+
+namespace FrontEnd.Responses
+{
+    public class DailyMovieSchedule
+    {
+        public string Date { get; set; }
+        public string DayOfWeek { get; set; }
+        public List<ShowtimeItem> Showtimes { get; set; } = new List<ShowtimeItem>();
+    }
+} 

--- a/FrontEnd/Responses/MovieDetailSchedule.cs
+++ b/FrontEnd/Responses/MovieDetailSchedule.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using FrontEnd.Models;
+
+namespace FrontEnd.Responses
+{
+    public class MovieDetailSchedule
+    {
+        public int Id { get; set; }
+        public string Title { get; set; }
+        public string Description { get; set; }
+        public int DurationMinutes { get; set; }
+        public string Genre { get; set; }
+        public string AgeRating { get; set; }
+        public string PosterUrl { get; set; }
+        public string BackdropUrl { get; set; }
+        public List<FormatInfo> Formats { get; set; } = new List<FormatInfo>();
+        public List<DailyMovieSchedule> Schedule { get; set; } = new List<DailyMovieSchedule>();
+    }
+} 

--- a/FrontEnd/View/MovieDetail.razor
+++ b/FrontEnd/View/MovieDetail.razor
@@ -1,5 +1,6 @@
 ﻿@page "/film/{Id:int}"
 @using FrontEnd.Models
+@using FrontEnd.Models.Responses
 @using System.Globalization
 @inject HttpClient Http
 @inject IJSRuntime JS
@@ -89,6 +90,7 @@
             
             <div class="showtimes-date-heading">
                 <h3>@SelectedDate.ToString("dddd, MMMM d", CultureInfo.InvariantCulture)</h3>
+                <a href="/schedule?movieId=@Id" class="view-all-showtimes">View all showtimes</a>
             </div>
             
             <div class="showtimes-list">
@@ -98,7 +100,7 @@
                     {
                         @if (presentation != null && 
                             (string.IsNullOrEmpty(selectedFormat) || 
-                            (presentation.Format != null && presentation.Format.Equals(selectedFormat, StringComparison.OrdinalIgnoreCase))))
+                            (presentation.Format != null && string.Equals(presentation.Format, selectedFormat, StringComparison.OrdinalIgnoreCase))))
                         {
                             <div class="showtime-item">
                                 <div class="showtime-format">@(presentation.Format ?? "Standard")</div>
@@ -343,19 +345,6 @@
             // For example, show a notification or search for the trailer on YouTube
             string searchQuery = Uri.EscapeDataString($"{Movie.Title} official trailer");
             await JS.InvokeVoidAsync("open", $"https://www.youtube.com/results?search_query={searchQuery}", "_blank");
-        }
-    }
-    
-    private async Task CheckPresentationsEndpoint()
-    {
-        try
-        {
-            var response = await Http.GetAsync($"api/presentations/movie/{Id}");
-            DirectPresentationsResponse = await response.Content.ReadAsStringAsync();
-        }
-        catch (Exception ex)
-        {
-            DirectPresentationsResponse = $"Error: {ex.Message}";
         }
     }
     

--- a/FrontEnd/wwwroot/css/movie-detail.css
+++ b/FrontEnd/wwwroot/css/movie-detail.css
@@ -672,4 +672,33 @@
     text-align: center;
     margin-bottom: 30px;
     color: #fff;
+}
+
+.showtimes-date-heading {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 30px;
+}
+
+.showtimes-date-heading h3 {
+    font-size: 24px;
+    font-weight: 600;
+    color: #f5c518;
+    margin: 0;
+}
+
+.view-all-showtimes {
+    color: #f5c518;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 14px;
+    display: flex;
+    align-items: center;
+    transition: color 0.2s;
+}
+
+.view-all-showtimes:hover {
+    color: #ffce29;
+    text-decoration: underline;
 } 

--- a/FrontEnd/wwwroot/css/schedule.css
+++ b/FrontEnd/wwwroot/css/schedule.css
@@ -1,0 +1,500 @@
+/* Schedule Page Styles */
+.schedule-container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 40px;
+    color: white;
+}
+
+.page-title {
+    font-size: 32px;
+    margin-bottom: 30px;
+    font-weight: 700;
+    color: white;
+}
+
+/* Filters Section */
+.filters-section {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 30px;
+    background-color: rgba(20, 24, 36, 0.8);
+    padding: 15px 20px;
+    border-radius: 4px;
+    border: 1px solid #1d2448;
+}
+
+.filter-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.filter-item label {
+    font-weight: 500;
+    color: #ccc;
+}
+
+.filter-item select {
+    background-color: #0f1628;
+    color: white;
+    border: 1px solid #1d2448;
+    border-radius: 4px;
+    padding: 8px 12px;
+    cursor: pointer;
+    min-width: 150px;
+}
+
+.filter-item select:focus {
+    outline: none;
+    border-color: #f5c518;
+}
+
+.btn-reset-filters {
+    background-color: transparent;
+    color: #f5c518;
+    border: 1px solid #f5c518;
+    border-radius: 4px;
+    padding: 8px 15px;
+    cursor: pointer;
+    font-weight: 600;
+    transition: all 0.2s;
+    margin-left: auto;
+}
+
+.btn-reset-filters:hover {
+    background-color: rgba(245, 197, 24, 0.1);
+}
+
+/* Date Navigation */
+.dates-nav {
+    display: flex;
+    gap: 10px;
+    overflow-x: auto;
+    padding-bottom: 15px;
+    margin-bottom: 25px;
+    scrollbar-width: thin;
+    scrollbar-color: #f5c518 #0f1628;
+}
+
+.dates-nav::-webkit-scrollbar {
+    height: 6px;
+}
+
+.dates-nav::-webkit-scrollbar-thumb {
+    background-color: #f5c518;
+    border-radius: 3px;
+}
+
+.date-btn {
+    min-width: 80px;
+    height: 70px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background-color: #0f1628;
+    border: 1px solid #1d2448;
+    border-radius: 4px;
+    padding: 10px;
+    color: white;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.date-btn:hover {
+    background-color: #1c2647;
+    transform: translateY(-2px);
+}
+
+.date-btn.active {
+    background-color: #f5c518;
+    color: black;
+    border-color: #f5c518;
+}
+
+.date-day {
+    font-size: 14px;
+    text-transform: uppercase;
+    font-weight: 500;
+}
+
+.date-num {
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 1;
+    margin: 2px 0;
+}
+
+.date-btn.active .date-num {
+    color: black;
+}
+
+.date-month {
+    font-size: 14px;
+    text-transform: uppercase;
+}
+
+/* Schedule Date Heading */
+.schedule-date-heading {
+    margin-bottom: 30px;
+}
+
+.schedule-date-heading h2 {
+    font-size: 24px;
+    font-weight: 600;
+    color: white;
+}
+
+/* Schedule Content */
+.schedule-content {
+    display: flex;
+    flex-direction: column;
+    gap: 40px;
+}
+
+.movie-schedule-item {
+    background-color: rgba(20, 24, 36, 0.8);
+    border: 1px solid #1d2448;
+    border-radius: 8px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+    transition: transform 0.2s;
+}
+
+.movie-schedule-item:hover {
+    transform: translateY(-5px);
+}
+
+.movie-info {
+    display: flex;
+    padding: 20px;
+    border-bottom: 1px solid #1d2448;
+}
+
+.movie-poster-link {
+    flex-shrink: 0;
+    width: 100px;
+    height: 150px;
+    overflow: hidden;
+    border-radius: 4px;
+    margin-right: 20px;
+}
+
+.movie-poster {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 0.3s;
+}
+
+.movie-poster:hover {
+    transform: scale(1.05);
+}
+
+.movie-details {
+    flex-grow: 1;
+}
+
+.movie-title {
+    font-size: 22px;
+    font-weight: 700;
+    margin-bottom: 10px;
+}
+
+.movie-title a {
+    color: white;
+    text-decoration: none;
+    transition: color 0.2s;
+}
+
+.movie-title a:hover {
+    color: #f5c518;
+}
+
+.movie-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 15px;
+    color: #ccc;
+}
+
+.movie-duration {
+    font-weight: 500;
+}
+
+.format-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.format-badge {
+    background-color: transparent;
+    border: 1px solid #f5c518;
+    color: #f5c518;
+    font-size: 12px;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 3px;
+}
+
+/* Showtimes Container */
+.showtimes-container {
+    padding: 20px;
+}
+
+.showtimes-container h4 {
+    margin-bottom: 15px;
+    font-weight: 600;
+    color: #ccc;
+    font-size: 16px;
+}
+
+.showtimes-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+}
+
+.showtime-btn {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: #0f1628;
+    border: 1px solid #1d2448;
+    border-radius: 6px;
+    padding: 12px 15px;
+    min-width: 110px;
+    text-align: center;
+    color: white;
+    text-decoration: none;
+    transition: all 0.2s;
+}
+
+.showtime-btn:hover {
+    background-color: #1c2647;
+    transform: translateY(-2px);
+    color: white;
+}
+
+.showtime-btn.almost-full {
+    border-color: #e74c3c;
+    position: relative;
+    overflow: visible;
+    background-color: rgba(231, 76, 60, 0.1);
+    box-shadow: 0 0 0 1px #e74c3c;
+}
+
+.showtime-btn.sold-out {
+    border-color: #c0392b;
+    position: relative;
+    overflow: visible;
+    background-color: rgba(192, 57, 43, 0.15);
+    box-shadow: 0 0 0 1px #c0392b;
+    opacity: 0.9;
+    cursor: not-allowed;
+    pointer-events: none;
+}
+
+.showtime-btn.sold-out:hover {
+    transform: none;
+    background-color: rgba(192, 57, 43, 0.15);
+}
+
+.showtime-btn.sold-out .format {
+    text-decoration: line-through;
+    opacity: 0.7;
+}
+
+.time {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 5px;
+}
+
+.hall, .format {
+    font-size: 13px;
+    color: #ccc;
+}
+
+.format {
+    color: #f5c518;
+    font-weight: 600;
+    margin-top: 3px;
+}
+
+.availability-indicator {
+    position: absolute;
+    top: -10px;
+    left: -10px;
+    background-color: #e74c3c;
+    color: white;
+    font-size: 11px;
+    font-weight: 700;
+    padding: 4px 10px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+    transform: rotate(-5deg);
+    z-index: 5;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    animation: pulse 2s infinite;
+    white-space: nowrap;
+    pointer-events: none;
+}
+
+.sold-out-indicator {
+    background-color: #c0392b;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+    animation: none;
+    transform: rotate(-5deg) scale(1.05);
+}
+
+@keyframes pulse {
+    0% {
+        transform: rotate(-5deg) scale(1);
+    }
+    50% {
+        transform: rotate(-5deg) scale(1.05);
+    }
+    100% {
+        transform: rotate(-5deg) scale(1);
+    }
+}
+
+.no-showtimes {
+    color: #999;
+    font-style: italic;
+}
+
+/* Loading and Empty States */
+.loading-container,
+.no-schedule-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 50px 20px;
+    text-align: center;
+    color: #ccc;
+}
+
+.spinner-border {
+    display: inline-block;
+    width: 2rem;
+    height: 2rem;
+    border: 0.25rem solid #f5c518;
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: spinner 0.75s linear infinite;
+    margin-bottom: 15px;
+}
+
+@keyframes spinner {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* Responsive Adjustments */
+@media (max-width: 768px) {
+    .schedule-container {
+        padding: 20px;
+    }
+    
+    .filters-section {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 15px;
+    }
+    
+    .btn-reset-filters {
+        margin-left: 0;
+        width: 100%;
+    }
+    
+    .movie-info {
+        flex-direction: column;
+    }
+    
+    .movie-poster-link {
+        width: 120px;
+        margin-right: 0;
+        margin-bottom: 15px;
+    }
+    
+    .date-btn {
+        min-width: 60px;
+    }
+}
+
+@media (min-width: 768px) {
+    .movie-schedule-item {
+        flex-direction: row;
+    }
+    
+    .movie-info {
+        width: 40%;
+        border-bottom: none;
+        border-right: 1px solid #1d2448;
+    }
+    
+    .showtimes-container {
+        width: 60%;
+    }
+}
+
+.btn-inline {
+    background: none;
+    border: none;
+    color: #3498db;
+    text-decoration: underline;
+    cursor: pointer;
+    padding: 0 0.25rem;
+    font-size: inherit;
+    font-weight: 500;
+    transition: color 0.2s ease;
+}
+
+.btn-inline:hover {
+    color: #2980b9;
+    text-decoration: underline;
+}
+
+.no-schedule-message {
+    text-align: center;
+    padding: 2.5rem;
+    background-color: rgba(25, 33, 48, 0.7);
+    border-radius: 0.5rem;
+    margin: 2rem 0;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.no-schedule-message p {
+    color: #fff;
+    font-size: 1.1rem;
+    margin: 0;
+    line-height: 1.5;
+}
+
+.message-icon {
+    width: 32px;
+    height: 32px;
+    color: rgba(255, 255, 255, 0.7);
+    margin-bottom: 1rem;
+}
+
+.message-actions {
+    margin-top: 1rem;
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.8);
+} 

--- a/FrontEnd/wwwroot/js/site.js
+++ b/FrontEnd/wwwroot/js/site.js
@@ -6,6 +6,33 @@ window.scrollToElement = function (elementId) {
     }
 }; 
 
+// Add a function to navigate back with fallback
+window.navigateBack = function() {
+    // Check if there's at least one entry in the history (besides the current page)
+    if (window.history.length > 1) {
+        window.history.back();
+    } else {
+        // If no history, check if we came from schedule or movie detail
+        // by looking at the referrer URL
+        const referrer = document.referrer;
+        
+        if (referrer && referrer.includes('/schedule')) {
+            window.location.href = '/schedule';
+        } else if (referrer && referrer.includes('/film/')) {
+            // Extract the movie ID from the referrer if possible
+            const movieIdMatch = referrer.match(/\/film\/(\d+)/);
+            if (movieIdMatch && movieIdMatch[1]) {
+                window.location.href = `/film/${movieIdMatch[1]}`;
+            } else {
+                window.location.href = '/schedule';
+            }
+        } else {
+            // Default fallback to schedule page
+            window.location.href = '/schedule';
+        }
+    }
+};
+
 // Ensure the function is properly registered in the global scope
 // This is a more reliable way to expose functions to Blazor
 window.cinemaFunctions = {
@@ -14,5 +41,8 @@ window.cinemaFunctions = {
         if (element) {
             element.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
+    },
+    navigateBack: function() {
+        window.navigateBack();
     }
 }; 

--- a/WebApi/Controllers/PresentationsController.cs
+++ b/WebApi/Controllers/PresentationsController.cs
@@ -1,5 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using WebApi.Models;
 
 namespace WebApi.Controllers
@@ -9,10 +14,15 @@ namespace WebApi.Controllers
     public class PresentationsController : ControllerBase
     {
         private readonly ApplicationDbContext _context;
+        private readonly IMemoryCache _cache;
+        private readonly ILogger<PresentationsController> _logger;
+        private readonly TimeSpan _cacheDuration = TimeSpan.FromMinutes(10); // Default cache duration
 
-        public PresentationsController(ApplicationDbContext context)
+        public PresentationsController(ApplicationDbContext context, IMemoryCache cache, ILogger<PresentationsController> logger)
         {
             _context = context;
+            _cache = cache;
+            _logger = logger;
         }
 
         public record CreatePresentationRequest(
@@ -68,7 +78,7 @@ namespace WebApi.Controllers
                     s.Id,
                     s.RowNumber,
                     s.SeatNumber,
-                    IsAvailable = !occupiedSeatIds.Contains(s.Id) && s.IsAvailable // Check both conditions
+                    IsAvailable = !occupiedSeatIds.Contains(s.Id) // Only check if not in occupied seats list
                 })
                 .GroupBy(s => s.RowNumber)
                 .Select(g => new
@@ -188,6 +198,301 @@ namespace WebApi.Controllers
 
             Console.WriteLine($"Fetched Presentation: {id}, Hall: {presentation.Hall.Name}, Movie: {presentation.Movie.Title}");
             return Ok(response);
+        }
+
+        /// <summary>
+        /// Get movie schedule (presentations) by date range with filtering and sorting options
+        /// </summary>
+        /// <param name="startDate">Optional start date for the schedule (default: today)</param>
+        /// <param name="endDate">Optional end date for the schedule (default: 7 days from start date)</param>
+        /// <param name="movieId">Optional filter by movie ID</param>
+        /// <param name="hallId">Optional filter by hall ID</param>
+        /// <param name="format">Optional filter by format (e.g., "2D", "IMAX")</param>
+        /// <param name="sortBy">Sort by: "time" (default), "popularity" (based on available seats)</param>
+        /// <returns>List of presentations grouped by date and movie</returns>
+        [HttpGet("schedule")]
+        public async Task<ActionResult<object>> GetSchedule(
+            [FromQuery] DateTime? startDate = null,
+            [FromQuery] DateTime? endDate = null,
+            [FromQuery] int? movieId = null,
+            [FromQuery] int? hallId = null,
+            [FromQuery] string? format = null,
+            [FromQuery] string sortBy = "time")
+        {
+            try
+            {
+                // Set default date range if not provided
+                var actualStartDate = startDate ?? DateTime.Today;
+                var actualEndDate = endDate ?? actualStartDate.AddDays(7);
+
+                // Validate date range
+                if (actualEndDate < actualStartDate)
+                {
+                    return BadRequest("End date cannot be earlier than start date");
+                }
+
+                // Create cache key based on parameters
+                string cacheKey = $"schedule_{actualStartDate:yyyyMMdd}_{actualEndDate:yyyyMMdd}" +
+                                  $"_{movieId}_{hallId}_{format}_{sortBy}";
+
+                // Try to get from cache first
+                if (_cache.TryGetValue(cacheKey, out object cachedSchedule))
+                {
+                    _logger.LogInformation("Retrieved schedule from cache with key: {CacheKey}", cacheKey);
+                    return Ok(cachedSchedule);
+                }
+
+                // Build basic query for all presentations within date range
+                var query = _context.Presentations
+                    .Include(p => p.Movie)
+                    .Include(p => p.Hall)
+                    .Include(p => p.Tickets.Where(t => t.Status != TicketStatus.Cancelled))
+                    .Where(p => p.StartTime.Date >= actualStartDate.Date && 
+                                p.StartTime.Date <= actualEndDate.Date);
+
+                // Apply optional filters
+                if (movieId.HasValue)
+                {
+                    query = query.Where(p => p.MovieId == movieId.Value);
+                }
+
+                if (hallId.HasValue)
+                {
+                    query = query.Where(p => p.HallId == hallId.Value);
+                }
+
+                if (!string.IsNullOrEmpty(format))
+                {
+                    query = query.Where(p => p.Format.ToLower() == format.ToLower());
+                }
+
+                // Execute query and get presentations
+                var presentations = await query.ToListAsync();
+
+                // Calculate available seats for each presentation
+                foreach (var presentation in presentations)
+                {
+                    presentation.AvailableSeats = (presentation.Hall.Rows * presentation.Hall.SeatsPerRow) -
+                        presentation.Tickets.Count(t => t.Status != TicketStatus.Cancelled);
+                }
+
+                // Apply sorting
+                IEnumerable<Presentation> sortedPresentations;
+                switch (sortBy.ToLower())
+                {
+                    case "popularity":
+                        // Sort by number of occupied seats (most popular first)
+                        sortedPresentations = presentations
+                            .OrderByDescending(p => p.Tickets.Count(t => t.Status != TicketStatus.Cancelled));
+                        break;
+                    case "time":
+                    default:
+                        // Sort by start time (default)
+                        sortedPresentations = presentations.OrderBy(p => p.StartTime);
+                        break;
+                }
+
+                // Group presentations by date and movie
+                var groupedByDate = sortedPresentations
+                    .GroupBy(p => p.StartTime.Date)
+                    .OrderBy(g => g.Key)
+                    .Select(dateGroup => new
+                    {
+                        Date = dateGroup.Key.ToString("yyyy-MM-dd"),
+                        DayOfWeek = dateGroup.Key.DayOfWeek.ToString(),
+                        Movies = dateGroup
+                            .GroupBy(p => p.MovieId)
+                            .Select(movieGroup => new
+                            {
+                                MovieId = movieGroup.Key,
+                                Title = movieGroup.First().Movie.Title,
+                                Duration = movieGroup.First().Movie.DurationMinutes,
+                                Formats = movieGroup.Select(p => p.Format).Distinct().ToList(),
+                                PosterUrl = movieGroup.First().Movie.PosterUrl,
+                                Showtimes = movieGroup.Select(p => 
+                                {
+                                    // Calculate total seats and available seats
+                                    int totalSeats = p.Hall.Rows * p.Hall.SeatsPerRow;
+                                    int availableSeats = p.AvailableSeats;
+                                    
+                                    // Calculate if it's almost full - less than 15% seats available
+                                    bool isAlmostFull = availableSeats <= totalSeats * 0.15 && availableSeats > 0;
+                                    bool isSoldOut = availableSeats == 0;
+                                    
+                                    // Log for debugging
+                                    if (isAlmostFull)
+                                    {
+                                        _logger.LogInformation("Found almost full presentation: ID {PresentationId}, Movie: {Title}, Available: {Available}/{Total} ({Percentage:F1}%)",
+                                            p.Id, p.Movie.Title, availableSeats, totalSeats, (double)availableSeats / totalSeats * 100);
+                                    }
+                                    
+                                    if (isSoldOut)
+                                    {
+                                        _logger.LogInformation("Found sold out presentation: ID {PresentationId}, Movie: {Title}, Available: 0/{Total}",
+                                            p.Id, p.Movie.Title, totalSeats);
+                                    }
+                                    
+                                    return new
+                                    {
+                                        p.Id,
+                                        p.HallId,
+                                        HallName = p.Hall.Name,
+                                        StartTime = p.StartTime.ToString("HH:mm"),
+                                        EndTime = p.EndTime.ToString("HH:mm"),
+                                        p.Format,
+                                        p.Price,
+                                        TotalSeats = totalSeats,
+                                        AvailableSeats = availableSeats,
+                                        IsAlmostFull = isAlmostFull,
+                                        IsSoldOut = isSoldOut
+                                    };
+                                }).ToList()
+                            }).ToList()
+                    }).ToList();
+
+                // Store in cache for future requests
+                _cache.Set(cacheKey, groupedByDate, _cacheDuration);
+                _logger.LogInformation("Added schedule to cache with key: {CacheKey}", cacheKey);
+
+                return Ok(groupedByDate);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving schedule");
+                return StatusCode(500, "An error occurred while retrieving the schedule");
+            }
+        }
+        
+        /// <summary>
+        /// Get presentations for a specific movie by date range
+        /// </summary>
+        /// <param name="movieId">Movie ID</param>
+        /// <param name="startDate">Optional start date (default: today)</param>
+        /// <param name="endDate">Optional end date (default: 7 days from start date)</param>
+        /// <param name="format">Optional format filter</param>
+        /// <returns>Movie details with available showtimes</returns>
+        [HttpGet("movie/{movieId}")]
+        public async Task<ActionResult<object>> GetMovieSchedule(
+            int movieId,
+            [FromQuery] DateTime? startDate = null,
+            [FromQuery] DateTime? endDate = null,
+            [FromQuery] string? format = null)
+        {
+            try
+            {
+                // Set default date range if not provided
+                var actualStartDate = startDate ?? DateTime.Today;
+                var actualEndDate = endDate ?? actualStartDate.AddDays(7);
+
+                // Validate date range
+                if (actualEndDate < actualStartDate)
+                {
+                    return BadRequest("End date cannot be earlier than start date");
+                }
+
+                // Create cache key based on parameters
+                string cacheKey = $"movie_schedule_{movieId}_{actualStartDate:yyyyMMdd}_{actualEndDate:yyyyMMdd}_{format}";
+
+                // Try to get from cache first
+                if (_cache.TryGetValue(cacheKey, out object cachedSchedule))
+                {
+                    _logger.LogInformation("Retrieved movie schedule from cache with key: {CacheKey}", cacheKey);
+                    return Ok(cachedSchedule);
+                }
+
+                // Get movie details
+                var movie = await _context.Movies
+                    .Include(m => m.Formats)
+                    .FirstOrDefaultAsync(m => m.Id == movieId);
+
+                if (movie == null)
+                {
+                    return NotFound("Movie not found");
+                }
+
+                // Get presentations for this movie in the date range
+                var query = _context.Presentations
+                    .Include(p => p.Movie)
+                    .Include(p => p.Hall)
+                    .Include(p => p.Tickets.Where(t => t.Status != TicketStatus.Cancelled))
+                    .Where(p => p.MovieId == movieId &&
+                                p.StartTime.Date >= actualStartDate.Date &&
+                                p.StartTime.Date <= actualEndDate.Date);
+
+                // Apply format filter if provided
+                if (!string.IsNullOrEmpty(format))
+                {
+                    query = query.Where(p => p.Format.ToLower() == format.ToLower());
+                }
+
+                // Execute query and get presentations
+                var presentations = await query.ToListAsync();
+
+                // Calculate available seats and group by date
+                var groupedByDate = presentations
+                    .Select(p => new
+                    {
+                        p.Id,
+                        p.HallId,
+                        HallName = p.Hall.Name,
+                        p.StartTime,
+                        p.EndTime,
+                        p.Format,
+                        p.Price,
+                        TotalSeats = p.Hall.Rows * p.Hall.SeatsPerRow,
+                        AvailableSeats = (p.Hall.Rows * p.Hall.SeatsPerRow) - p.Tickets.Count(t => t.Status != TicketStatus.Cancelled),
+                        Date = p.StartTime.Date
+                    })
+                    .OrderBy(p => p.StartTime)
+                    .GroupBy(p => p.Date)
+                    .Select(g => new
+                    {
+                        Date = g.Key.ToString("yyyy-MM-dd"),
+                        DayOfWeek = g.Key.DayOfWeek.ToString(),
+                        Showtimes = g.Select(p => new
+                        {
+                            p.Id,
+                            p.HallId,
+                            p.HallName,
+                            StartTime = p.StartTime.ToString("HH:mm"),
+                            EndTime = p.EndTime.ToString("HH:mm"),
+                            p.Format,
+                            p.Price,
+                            p.TotalSeats,
+                            p.AvailableSeats,
+                            IsAlmostFull = p.AvailableSeats <= p.TotalSeats * 0.15 && p.AvailableSeats > 0, // Less than 15% seats available
+                            IsSoldOut = p.AvailableSeats == 0
+                        }).ToList()
+                    })
+                    .OrderBy(g => g.Date)
+                    .ToList();
+
+                // Create response with movie details and schedule
+                var result = new
+                {
+                    movie.Id,
+                    movie.Title,
+                    movie.Description,
+                    movie.DurationMinutes,
+                    movie.Genre,
+                    movie.AgeRating,
+                    movie.PosterUrl,
+                    movie.BackdropUrl,
+                    Formats = movie.Formats.Select(f => new { f.Name, f.Description }).ToList(),
+                    Schedule = groupedByDate
+                };
+
+                // Store in cache for future requests
+                _cache.Set(cacheKey, result, _cacheDuration);
+                _logger.LogInformation("Added movie schedule to cache with key: {CacheKey}", cacheKey);
+
+                return Ok(result);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving movie schedule for movie ID {MovieId}", movieId);
+                return StatusCode(500, "An error occurred while retrieving the movie schedule");
+            }
         }
     }
 }

--- a/WebApi/Controllers/TicketsController.cs
+++ b/WebApi/Controllers/TicketsController.cs
@@ -68,12 +68,9 @@ namespace WebApi.Controllers
 
                 await _context.SaveChangesAsync();
 
-                // Reset all seats to available first
-                foreach (var seat in presentation.Hall.Seats)
-                {
-                    seat.IsAvailable = true;
-                }
-                await _context.SaveChangesAsync();
+                // Reset all seats to available first using the service
+                var allSeatIds = presentation.Hall.Seats.Select(s => s.Id).ToList();
+                await _ticketService.UpdateSeatAvailability(allSeatIds, true, presentationId);
 
                 // Get all seats in the hall
                 var allSeats = presentation.Hall.Seats
@@ -96,12 +93,18 @@ namespace WebApi.Controllers
                     row5.Where(s => !seatsToLeaveEmpty.Contains(s.SeatNumber)) // Add row 5 seats that should be booked
                 ).ToList();
 
-                // Set IsAvailable = false for all seats that will be booked
-                foreach (var seat in seatsToBook)
+                // Mark seats as unavailable using the service
+                var seatIds = seatsToBook.Select(s => s.Id).ToList();
+                await _ticketService.UpdateSeatAvailability(seatIds, false, presentationId);
+
+                // Update the presentation's AvailableSeats to match
+                if (presentation != null && presentation.Hall != null)
                 {
-                    seat.IsAvailable = false;
+                    int totalSeats = presentation.Hall.Rows * presentation.Hall.SeatsPerRow;
+                    int bookedSeats = seatsToBook.Count;
+                    presentation.AvailableSeats = totalSeats - bookedSeats;
+                    await _context.SaveChangesAsync();
                 }
-                await _context.SaveChangesAsync();
 
                 // Create a mock ticket order for our test tickets
                 var mockOrder = new TicketOrder
@@ -153,6 +156,51 @@ namespace WebApi.Controllers
                 await transaction.RollbackAsync();
                 _logger.LogError(ex, "Error setting up split scenario");
                 return new ObjectResult("An error occurred") { StatusCode = 500 };
+            }
+        }
+
+        [HttpPost("test/reset-seats")]
+        public async Task<ActionResult> ResetSeatAvailability(int presentationId)
+        {
+            try
+            {
+                // Get the presentation
+                var presentation = await _context.Presentations
+                    .Include(p => p.Hall)
+                    .FirstOrDefaultAsync(p => p.Id == presentationId);
+                
+                if (presentation == null || presentation.Hall == null)
+                {
+                    return NotFound($"Presentation {presentationId} not found");
+                }
+
+                // Get all seats for this hall
+                var seats = await _context.Seats
+                    .Where(s => s.HallId == presentation.HallId)
+                    .ToListAsync();
+                    
+                var seatIds = seats.Select(s => s.Id).ToList();
+                
+                // Call the service to mark all seats as available
+                await _ticketService.UpdateSeatAvailability(seatIds, true, presentationId);
+                
+                // Also remove any existing seat locks
+                var existingLocks = await _context.SeatLocks
+                    .Where(l => l.PresentationId == presentationId)
+                    .ToListAsync();
+                    
+                if (existingLocks.Any())
+                {
+                    _context.SeatLocks.RemoveRange(existingLocks);
+                    await _context.SaveChangesAsync();
+                }
+                
+                return Ok($"Reset {seatIds.Count} seats to available for presentation {presentationId}");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error resetting seat availability for presentation {PresentationId}", presentationId);
+                return StatusCode(500, "An error occurred while resetting seat availability");
             }
         }
 
@@ -288,43 +336,41 @@ namespace WebApi.Controllers
         {
             try
             {
+                _logger.LogInformation("StartGroupOrder called with PresentationId: {PresentationId}, NumberOfSeats: {NumberOfSeats}", 
+                    request.PresentationId, request.NumberOfSeats);
+
                 if (request.PresentationId <= 0)
                 {
+                    _logger.LogWarning("Invalid presentation ID: {PresentationId}", request.PresentationId);
                     return NotFound("Presentation not found");
                 }
 
                 if (request.NumberOfSeats <= 0 || request.NumberOfSeats > 20)
                 {
+                    _logger.LogWarning("Invalid number of seats requested: {NumberOfSeats}", request.NumberOfSeats);
                     return BadRequest("Invalid number of seats requested");
                 }
 
                 var response = await _ticketService.StartGroupOrder(request);
                 if (response == null)
                 {
-                    return BadRequest("No seats available");
+                    _logger.LogWarning("StartGroupOrder returned null response for presentation {PresentationId}", request.PresentationId);
+                    return BadRequest("Failed to create order");
                 }
 
-                // Lock all potential seats across all options
-                var allPotentialSeatIds = response.AvailableOptions.Values
-                    .SelectMany(o => o.SeatIds)
-                    .Distinct()
-                    .ToList();
-
-                var success = await TryLockSeats(allPotentialSeatIds, response.OrderToken, request.PresentationId);
-                if (!success)
-                {
-                    return BadRequest("Failed to lock seats");
-                }
-
+                _logger.LogInformation("Successfully created group order with token {OrderToken} for presentation {PresentationId}", 
+                    response.OrderToken, request.PresentationId);
                 return Ok(response);
             }
-            catch (NoSeatsAvailableException ex)
+            catch (NoSeatsAvailableException)
             {
-                return BadRequest(ex.Message);
+                _logger.LogWarning("No seats available for presentation {PresentationId}", request.PresentationId);
+                return BadRequest("No seats available");
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error starting group order");
+                _logger.LogError(ex, "Error starting group order for presentation {PresentationId}, seats: {NumberOfSeats}: {ErrorMessage}",
+                    request.PresentationId, request.NumberOfSeats, ex.Message);
                 return StatusCode(500, "An error occurred");
             }
         }
@@ -379,15 +425,9 @@ namespace WebApi.Controllers
 
                     // Make unselected seats available again
                     var seatIdsToMakeAvailable = seatsToUnlock.Select(l => l.SeatId).ToList();
-                    var seatsToMakeAvailable = await _context.Seats
-                        .Where(s => seatIdsToMakeAvailable.Contains(s.Id))
-                        .ToListAsync();
 
-                    foreach (var seat in seatsToMakeAvailable)
-                    {
-                        seat.IsAvailable = true;
-                    }
-                    await _context.SaveChangesAsync();
+                    // Make seats available again using the service
+                    await _ticketService.UpdateSeatAvailability(seatIdsToMakeAvailable, true, order.PresentationId);
                 }
 
                 return Ok(response);
@@ -600,6 +640,463 @@ namespace WebApi.Controllers
             }
         }
 
+        [HttpGet("test/almost-sold-out-test")]
+        public async Task<ActionResult> SetupAlmostSoldOutTest()
+        {
+            try
+            {
+                // First, let's get a movie to create presentations for
+                var movie = await _context.Movies
+                    .FirstOrDefaultAsync(m => m.IsActive);
+                
+                if (movie == null)
+                {
+                    return NotFound("No active movies found in the database");
+                }
+                
+                // Get halls to use for our test presentations
+                var halls = await _context.Halls.Take(3).ToListAsync();
+                if (halls.Count < 1)
+                {
+                    return NotFound("No halls found in the database");
+                }
+                
+                // Create presentations for the next 7 days instead of just today
+                var startDate = DateTime.Today;
+                var endDate = startDate.AddDays(6); // 7 days total (today + 6 more days)
+                
+                // Get the current time to ensure we don't create presentations in the past for today
+                var currentTime = DateTime.Now.TimeOfDay;
+                
+                var allResults = new List<object>();
+                var allCreatedOrUpdated = new List<Presentation>();
+                
+                // Iterate through each day in our date range
+                for (var testDate = startDate; testDate <= endDate; testDate = testDate.AddDays(1))
+                {
+                    var isToday = testDate.Date == DateTime.Today;
+                    
+                    // Create startTimes - for today, ensure they're in the future
+                    // For other days, use consistent times
+                    var startTimes = new List<TimeSpan>();
+                    
+                    // Base times that will be used for all days
+                    var baseTimes = new List<TimeSpan>
+                    {
+                        new TimeSpan(10, 0, 0),   // 10:00 AM
+                        new TimeSpan(14, 30, 0),  // 2:30 PM
+                        new TimeSpan(17, 0, 0),   // 5:00 PM
+                        new TimeSpan(19, 30, 0),  // 7:30 PM
+                        new TimeSpan(21, 0, 0),   // 9:00 PM
+                        new TimeSpan(22, 15, 0)   // 10:15 PM
+                    };
+                    
+                    // For today, filter out times that have already passed
+                    if (isToday)
+                    {
+                        startTimes = baseTimes.Where(t => t > currentTime.Add(new TimeSpan(0, 30, 0))).ToList();
+                        
+                        // If all times have passed for today, add some times for late evening
+                        if (!startTimes.Any())
+                        {
+                            // Add a couple of late evening times if it's still early enough
+                            var currentHour = currentTime.Hours;
+                            if (currentHour < 22)
+                            {
+                                startTimes.Add(new TimeSpan(22, 0, 0));  // 10:00 PM
+                                startTimes.Add(new TimeSpan(23, 30, 0));  // 11:30 PM
+                            }
+                            else if (currentHour < 23)
+                            {
+                                startTimes.Add(new TimeSpan(23, 30, 0));  // 11:30 PM
+                            }
+                        }
+                    }
+                    else
+                    {
+                        // For future days, use all base times
+                        startTimes = baseTimes;
+                    }
+                    
+                    // Skip this day if we don't have any valid start times
+                    if (!startTimes.Any())
+                    {
+                        continue;
+                    }
+                    
+                    var results = new List<object>();
+                    var createdOrUpdated = new List<Presentation>();
+                    
+                    // For each hall, set up presentations with different levels of availability
+                    foreach (var hall in halls)
+                    {
+                        // Get total seats in this hall
+                        int totalSeats = hall.Rows * hall.SeatsPerRow;
+                        
+                        // Create availability scenarios:
+                        // 1. Completely sold out (0% seats remaining)
+                        // 2. Almost sold out (less than 15% seats remaining)
+                        // 3. Moderately full (30-50% seats remaining)
+                        // 4. Plenty available (70-90% seats remaining)
+                        var availabilityScenarios = new[] {
+                            0,                          // 0% available (completely sold out)
+                            (int)(totalSeats * 0.05),   // 5% available (almost sold out)
+                            (int)(totalSeats * 0.35),   // 35% available (moderately full)
+                            (int)(totalSeats * 0.8)     // 80% available (plenty available)
+                        };
+                        
+                        // Limit how many scenarios we use based on available time slots
+                        int maxScenarios = Math.Min(startTimes.Count, availabilityScenarios.Length);
+                        
+                        for (int i = 0; i < maxScenarios; i++)
+                        {
+                            var startTime = startTimes[i];
+                            var availableSeats = availabilityScenarios[i];
+                            
+                            // Create a start DateTime and calculate end time based on movie duration
+                            var presentationStart = testDate.Add(startTime);
+                            var presentationEnd = presentationStart.AddMinutes(movie.DurationMinutes);
+                            
+                            // Create or update a test presentation
+                            var presentation = await _context.Presentations
+                                .FirstOrDefaultAsync(p => 
+                                    p.MovieId == movie.Id && 
+                                    p.HallId == hall.Id && 
+                                    p.StartTime.Date == testDate.Date && 
+                                    p.StartTime.Hour == presentationStart.Hour);
+                                    
+                            if (presentation == null)
+                            {
+                                // Create new presentation
+                                presentation = new Presentation
+                                {
+                                    MovieId = movie.Id,
+                                    Movie = movie,
+                                    HallId = hall.Id,
+                                    Hall = hall,
+                                    StartTime = presentationStart,
+                                    EndTime = presentationEnd,
+                                    Price = 12.50m,
+                                    Format = i == 0 ? "2D" : (i == 1 ? "3D" : "IMAX"),
+                                    HallName = hall.Name,
+                                    AvailableSeats = availableSeats,
+                                    CreatedAt = DateTime.UtcNow,
+                                    UpdatedAt = DateTime.UtcNow
+                                };
+                                
+                                _context.Presentations.Add(presentation);
+                            }
+                            else
+                            {
+                                // Update existing presentation
+                                presentation.AvailableSeats = availableSeats;
+                                presentation.UpdatedAt = DateTime.UtcNow;
+                            }
+                            
+                            await _context.SaveChangesAsync();
+                            createdOrUpdated.Add(presentation);
+                            
+                            // Create or update seat presentations for this presentation
+                            await EnsureSeatPresentationsExist(presentation.Id, availableSeats, totalSeats);
+                            
+                            // Add presentation with availability info to results
+                            results.Add(new {
+                                PresentationId = presentation.Id,
+                                Date = presentation.StartTime.ToShortDateString(),
+                                HallName = hall.Name,
+                                MovieTitle = movie.Title,
+                                StartTime = presentation.StartTime.ToString("HH:mm"),
+                                Format = presentation.Format,
+                                TotalSeats = totalSeats,
+                                AvailableSeats = availableSeats,
+                                SoldOutPercentage = 100 - (availableSeats * 100 / totalSeats),
+                                AlmostSoldOut = availableSeats > 0 && availableSeats <= totalSeats * 0.15,
+                                SoldOut = availableSeats == 0
+                            });
+                        }
+                    }
+                    
+                    // Add this day's results to the overall results
+                    allResults.AddRange(results);
+                    allCreatedOrUpdated.AddRange(createdOrUpdated);
+                }
+                
+                // Group results by date for better presentation
+                var groupedResults = allResults
+                    .GroupBy(r => ((dynamic)r).Date)
+                    .Select(g => new {
+                        Date = g.Key,
+                        Presentations = g.ToList()
+                    })
+                    .OrderBy(g => DateTime.Parse(g.Date))
+                    .ToList();
+                
+                return Ok(new {
+                    DateRange = $"{startDate:yyyy-MM-dd} to {endDate:yyyy-MM-dd}",
+                    PresentationsCreated = allCreatedOrUpdated.Count,
+                    Note = "These presentations are available in the regular schedule. Refresh the schedule page to view them.",
+                    ScheduleByDay = groupedResults
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error setting up almost sold out test");
+                return StatusCode(500, $"Error setting up test: {ex.Message}");
+            }
+        }
+        
+        // Helper method to create or update seat presentations for a given presentation
+        private async Task EnsureSeatPresentationsExist(int presentationId, int availableSeats, int totalSeats)
+        {
+            // Get seats for this presentation's hall
+            var presentation = await _context.Presentations
+                .Include(p => p.Hall)
+                .ThenInclude(h => h.Seats)
+                .FirstOrDefaultAsync(p => p.Id == presentationId);
+                
+            if (presentation == null || presentation.Hall == null || !presentation.Hall.Seats.Any())
+                return;
+                
+            // Get all the seats
+            var seats = presentation.Hall.Seats.ToList();
+            if (!seats.Any())
+                return;
+                
+            // Calculate how many seats should be unavailable
+            int unavailableCount = totalSeats - availableSeats;
+            
+            // Get existing seat presentations
+            var existingSeatPresentations = await _context.SeatPresentations
+                .Where(sp => sp.PresentationId == presentationId)
+                .ToListAsync();
+                
+            // If no existing seat presentations, create them
+            if (!existingSeatPresentations.Any())
+            {
+                _logger.LogInformation($"Creating {seats.Count} new seat presentations for presentation {presentationId}");
+                
+                // Shuffle the seats to randomize which ones are available
+                var random = new Random(presentationId); // Use presentation ID as seed for consistent results
+                var shuffledSeats = seats.OrderBy(s => random.Next()).ToList();
+                
+                // Create seat presentations for all seats
+                var seatPresentations = new List<SeatPresentation>();
+                
+                for (int i = 0; i < shuffledSeats.Count; i++)
+                {
+                    var seat = shuffledSeats[i];
+                    var isAvailable = i >= unavailableCount; // First 'unavailableCount' seats are not available
+                    
+                    seatPresentations.Add(new SeatPresentation
+                    {
+                        SeatId = seat.Id,
+                        PresentationId = presentationId,
+                        IsAvailable = isAvailable,
+                        CreatedAt = DateTime.UtcNow,
+                        UpdatedAt = DateTime.UtcNow
+                    });
+                }
+                
+                await _context.SeatPresentations.AddRangeAsync(seatPresentations);
+                await _context.SaveChangesAsync();
+                
+                _logger.LogInformation($"Created {seatPresentations.Count} seat presentations with {availableSeats} available seats");
+
+                // Create actual ticket orders and tickets for unavailable seats
+                await CreateFakeTicketOrders(shuffledSeats.Take(unavailableCount).Select(s => s.Id).ToList(), presentationId);
+            }
+            else
+            {
+                _logger.LogInformation($"Updating {existingSeatPresentations.Count} existing seat presentations for presentation {presentationId}");
+                
+                // Update existing seat presentations
+                // Make sure we have a record for every seat
+                var existingSeatIds = existingSeatPresentations.Select(sp => sp.SeatId).ToHashSet();
+                var missingSeatPresentations = new List<SeatPresentation>();
+                
+                foreach (var seat in seats)
+                {
+                    if (!existingSeatIds.Contains(seat.Id))
+                    {
+                        missingSeatPresentations.Add(new SeatPresentation
+                        {
+                            SeatId = seat.Id,
+                            PresentationId = presentationId,
+                            IsAvailable = true, // Default to available
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow
+                        });
+                    }
+                }
+                
+                if (missingSeatPresentations.Any())
+                {
+                    _logger.LogInformation($"Adding {missingSeatPresentations.Count} missing seat presentations");
+                    await _context.SeatPresentations.AddRangeAsync(missingSeatPresentations);
+                    await _context.SaveChangesAsync();
+                    
+                    // Refresh the list of all seat presentations
+                    existingSeatPresentations = await _context.SeatPresentations
+                        .Where(sp => sp.PresentationId == presentationId)
+                        .ToListAsync();
+                }
+                
+                // Shuffle for random availability - use a combination of presentation ID and current time
+                // for a different result each time
+                var random = new Random(presentationId + (int)DateTime.Now.Ticks % 10000);
+                var shuffledPresentations = existingSeatPresentations.OrderBy(s => random.Next()).ToList();
+                
+                // Get the unavailable seat IDs
+                var unavailableSeatIds = new List<int>();
+                
+                // Update availability based on our desired number of available seats
+                for (int i = 0; i < shuffledPresentations.Count; i++)
+                {
+                    var isAvailable = i >= unavailableCount;
+                    if (shuffledPresentations[i].IsAvailable != isAvailable)
+                    {
+                        shuffledPresentations[i].IsAvailable = isAvailable;
+                        shuffledPresentations[i].UpdatedAt = DateTime.UtcNow;
+                        
+                        if (!isAvailable)
+                        {
+                            unavailableSeatIds.Add(shuffledPresentations[i].SeatId);
+                        }
+                    }
+                }
+                
+                await _context.SaveChangesAsync();
+                _logger.LogInformation($"Updated seat presentations to have {availableSeats} available seats");
+                
+                // Create tickets for the newly unavailable seats
+                if (unavailableSeatIds.Any())
+                {
+                    // First, remove any existing tickets or locks for these seats to avoid conflicts
+                    var existingTickets = await _context.Tickets
+                        .Where(t => t.PresentationId == presentationId && unavailableSeatIds.Contains(t.SeatId))
+                        .ToListAsync();
+                    
+                    if (existingTickets.Any())
+                    {
+                        _context.Tickets.RemoveRange(existingTickets);
+                        await _context.SaveChangesAsync();
+                    }
+                    
+                    var existingLocks = await _context.SeatLocks
+                        .Where(l => l.PresentationId == presentationId && unavailableSeatIds.Contains(l.SeatId))
+                        .ToListAsync();
+                    
+                    if (existingLocks.Any())
+                    {
+                        _context.SeatLocks.RemoveRange(existingLocks);
+                        await _context.SaveChangesAsync();
+                    }
+                    
+                    // Now create new ticket orders and tickets
+                    await CreateFakeTicketOrders(unavailableSeatIds, presentationId);
+                }
+            }
+        }
+        
+        // Helper method to create fake ticket orders and tickets
+        private async Task CreateFakeTicketOrders(List<int> seatIds, int presentationId)
+        {
+            if (!seatIds.Any())
+                return;
+                
+            _logger.LogInformation($"Creating fake ticket orders for {seatIds.Count} seats in presentation {presentationId}");
+            
+            // Create tickets in batches of 1-4 seats per order
+            var random = new Random(presentationId);
+            var remainingSeats = new List<int>(seatIds);
+            
+            while (remainingSeats.Any())
+            {
+                // Determine batch size (1-4 seats per order)
+                int batchSize = Math.Min(random.Next(1, 5), remainingSeats.Count);
+                var batchSeatIds = remainingSeats.Take(batchSize).ToList();
+                remainingSeats.RemoveRange(0, batchSize);
+                
+                // Create a new ticket order
+                var orderToken = Guid.NewGuid();
+                var orderTimestamp = DateTime.UtcNow.AddMinutes(-random.Next(5, 60)); // Random time in the past
+                
+                // Get the presentation
+                var presentation = await _context.Presentations.FindAsync(presentationId);
+                if (presentation == null)
+                {
+                    _logger.LogError($"Presentation {presentationId} not found when creating fake orders");
+                    continue;
+                }
+                
+                var order = new TicketOrder
+                {
+                    PresentationId = presentationId,
+                    OrderToken = orderToken,
+                    Status = OrderStatus.Confirmed, // Order is confirmed
+                    CreatedAt = orderTimestamp,
+                    ExpiresAt = orderTimestamp.AddMinutes(10), // Already expired
+                    Items = new List<TicketOrderItem>()
+                };
+                
+                _context.TicketOrders.Add(order);
+                await _context.SaveChangesAsync(); // Save to get the order ID
+                
+                // Create order items
+                foreach (var seatId in batchSeatIds)
+                {
+                    order.Items.Add(new TicketOrderItem
+                    {
+                        TicketOrderId = order.Id,
+                        SeatId = seatId,
+                        CreatedAt = orderTimestamp
+                    });
+                }
+                
+                await _context.SaveChangesAsync();
+                
+                // Create tickets
+                var tickets = new List<Ticket>();
+                var customerName = $"Test Customer {random.Next(1000, 9999)}";
+                var customerEmail = $"test{random.Next(1000, 9999)}@example.com";
+                
+                foreach (var seatId in batchSeatIds)
+                {
+                    var seat = await _context.Seats.FindAsync(seatId);
+                    
+                    if (seat != null)
+                    {
+                        // Create a new ticket with all required properties
+                        var ticket = new Ticket
+                        {
+                            PresentationId = presentationId,
+                            SeatId = seatId,
+                            TicketOrderId = order.Id,
+                            CustomerName = customerName,
+                            CustomerEmail = customerEmail,
+                            Status = TicketStatus.Reserved,
+                            PurchaseDate = orderTimestamp,
+                            CreatedAt = orderTimestamp,
+                            UpdatedAt = orderTimestamp,
+                            Presentation = presentation,
+                            Seat = seat,
+                            TicketOrder = order
+                        };
+                        
+                        tickets.Add(ticket);
+                    }
+                }
+                
+                if (tickets.Any())
+                {
+                    await _context.Tickets.AddRangeAsync(tickets);
+                    await _context.SaveChangesAsync();
+                }
+            }
+            
+            _logger.LogInformation($"Successfully created fake ticket orders for presentation {presentationId}");
+        }
+
         private async Task<bool> TryLockSeats(List<int> seatIds, Guid orderToken, int presentationId)
         {
             try
@@ -637,16 +1134,9 @@ namespace WebApi.Controllers
 
                 await _context.SaveChangesAsync();
 
-                // Now update the seat availability
-                foreach (var seatId in seatIds)
-                {
-                    var seat = await _context.Seats.FindAsync(seatId);
-                    if (seat != null)
-                    {
-                        seat.IsAvailable = false; // Set the seat availability to false
-                        await _context.SaveChangesAsync(); // Save changes to the database
-                    }
-                }
+                // Use the ticket service to update seat availability 
+                // This will also update the presentation's AvailableSeats count
+                await _ticketService.UpdateSeatAvailability(seatIds, false, presentationId);
 
                 return true;
             }

--- a/WebApi/Data/ApplicationDbContext.cs
+++ b/WebApi/Data/ApplicationDbContext.cs
@@ -20,6 +20,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<TicketOrderItem> TicketOrderItems { get; set; } = null!;
     public DbSet<SeatLock> SeatLocks { get; set; } = null!;
     public DbSet<MovieFormat> MovieFormats { get; set; } = null!;
+    public DbSet<SeatPresentation> SeatPresentations { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -34,6 +35,21 @@ public class ApplicationDbContext : DbContext
             .HasOne(s => s.Hall)
             .WithMany(h => h.Seats) // Ensure this is set to the collection in Hall
             .HasForeignKey(s => s.HallId);
+
+        // Configure SeatPresentation entity
+        modelBuilder.Entity<SeatPresentation>()
+            .HasIndex(sp => new { sp.SeatId, sp.PresentationId })
+            .IsUnique();
+
+        modelBuilder.Entity<SeatPresentation>()
+            .HasOne(sp => sp.Seat)
+            .WithMany()
+            .HasForeignKey(sp => sp.SeatId);
+
+        modelBuilder.Entity<SeatPresentation>()
+            .HasOne(sp => sp.Presentation)
+            .WithMany()
+            .HasForeignKey(sp => sp.PresentationId);
 
         modelBuilder.Entity<Ticket>()
             .HasIndex(t => new { t.PresentationId, t.SeatId })

--- a/WebApi/Data/DbSeeder.cs
+++ b/WebApi/Data/DbSeeder.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using WebApi.Models;
+using static WebApi.Models.TicketStatus;
 
 namespace WebApi.Data
 {
@@ -7,6 +8,9 @@ namespace WebApi.Data
     {
         public static async Task Initialize(ApplicationDbContext context)
         {
+            // Update existing presentations' AvailableSeats if needed
+            await UpdatePresentationsAvailableSeats(context);
+            
             // Seed halls
             if (!await context.Halls.AnyAsync())
             {
@@ -36,7 +40,6 @@ namespace WebApi.Data
                                 HallId = hall.Id, // Set HallId directly
                                 RowNumber = row,
                                 SeatNumber = seatNum,
-                                IsAvailable = true,
                                 CreatedAt = DateTime.UtcNow
                             });
                         }
@@ -243,6 +246,9 @@ namespace WebApi.Data
                                     // Set price between $10.99 and $18.99
                                     decimal price = 10.99m + (decimal)random.Next(0, 9);
                                     
+                                    // Calculate available seats as total hall capacity
+                                    int totalSeats = hall.Rows * hall.SeatsPerRow;
+
                                     // Create the presentation
                                     presentations.Add(new Presentation
                                     {
@@ -255,7 +261,9 @@ namespace WebApi.Data
                                         // Assign a random format from this movie's formats
                                         Format = movie.Formats != null && movie.Formats.Any() 
                                             ? movie.Formats.ElementAt(random.Next(movie.Formats.Count)).Name ?? "Standard"
-                                            : "Standard"
+                                            : "Standard",
+                                        // Set available seats to the total capacity of the hall
+                                        AvailableSeats = totalSeats
                                     });
                                 }
                             }
@@ -266,6 +274,95 @@ namespace WebApi.Data
                     }
                 }
             }
+
+            // Initialize SeatPresentation records for all presentations
+            await InitializeSeatPresentations(context);
+        }
+        
+        private static async Task UpdatePresentationsAvailableSeats(ApplicationDbContext context)
+        {
+            // Get presentations with AvailableSeats = 0
+            var presentationsToUpdate = await context.Presentations
+                .Include(p => p.Hall)
+                .Where(p => p.AvailableSeats == 0)
+                .ToListAsync();
+                
+            if (presentationsToUpdate.Any())
+            {
+                foreach (var presentation in presentationsToUpdate)
+                {
+                    if (presentation.Hall != null)
+                    {
+                        // Calculate total seats in the hall
+                        int totalSeats = presentation.Hall.Rows * presentation.Hall.SeatsPerRow;
+                        
+                        // Count booked tickets
+                        int bookedSeats = await context.Tickets
+                            .CountAsync(t => t.PresentationId == presentation.Id && t.Status != TicketStatus.Cancelled);
+                            
+                        // Set available seats
+                        presentation.AvailableSeats = totalSeats - bookedSeats;
+                    }
+                }
+                
+                await context.SaveChangesAsync();
+                Console.WriteLine($"Updated AvailableSeats for {presentationsToUpdate.Count} presentations");
+            }
+        }
+
+        private static async Task InitializeSeatPresentations(ApplicationDbContext context)
+        {
+            // Get all presentations that don't have any SeatPresentation records
+            var presentationsWithoutSeatPresentations = await context.Presentations
+                .Include(p => p.Hall)
+                .Where(p => !context.SeatPresentations.Any(sp => sp.PresentationId == p.Id))
+                .ToListAsync();
+            
+            if (!presentationsWithoutSeatPresentations.Any())
+            {
+                return; // No presentations need initialization
+            }
+            
+            Console.WriteLine($"Initializing SeatPresentation records for {presentationsWithoutSeatPresentations.Count} presentations...");
+            
+            foreach (var presentation in presentationsWithoutSeatPresentations)
+            {
+                // Get all seats for the presentation's hall
+                var seats = await context.Seats
+                    .Where(s => s.HallId == presentation.HallId)
+                    .ToListAsync();
+                
+                // Get existing tickets for this presentation
+                var bookedSeatIds = await context.Tickets
+                    .Where(t => t.PresentationId == presentation.Id && t.Status != TicketStatus.Cancelled)
+                    .Select(t => t.SeatId)
+                    .ToListAsync();
+                
+                // Create SeatPresentation records
+                var seatPresentations = new List<SeatPresentation>();
+                foreach (var seat in seats)
+                {
+                    seatPresentations.Add(new SeatPresentation
+                    {
+                        SeatId = seat.Id,
+                        PresentationId = presentation.Id,
+                        IsAvailable = !bookedSeatIds.Contains(seat.Id), // Only seats without tickets are available
+                        CreatedAt = DateTime.UtcNow,
+                        UpdatedAt = DateTime.UtcNow
+                    });
+                }
+                
+                // Add the SeatPresentation records to the context
+                await context.SeatPresentations.AddRangeAsync(seatPresentations);
+                
+                // Update the presentation's AvailableSeats count
+                presentation.AvailableSeats = seats.Count - bookedSeatIds.Count;
+                
+                Console.WriteLine($"Initialized {seatPresentations.Count} SeatPresentation records for presentation {presentation.Id}");
+            }
+            
+            // Save all changes to the database
+            await context.SaveChangesAsync();
         }
     }
 }

--- a/WebApi/Interfaces/Repositories/ITicketRepository.cs
+++ b/WebApi/Interfaces/Repositories/ITicketRepository.cs
@@ -7,6 +7,7 @@ namespace WebApi.Interfaces.Repositories
         Task<List<Seat>> GetAvailableSeats(int presentationId, bool findBest);
         Task<bool> AreSeatAvailable(int presentationId, List<int> seatIds, Guid? orderToken = null);
         Task<List<Seat>> GetSeatsByIds(List<int> seatIds);
+        Task<Seat?> GetSeatById(int seatId);
         Task<List<SeatLock>> GetExpiredLocks();
         Task RemoveSeatLocks(List<SeatLock> locks);
         Task<bool> AddSeatLocks(List<SeatLock> locks);
@@ -15,11 +16,14 @@ namespace WebApi.Interfaces.Repositories
         Task<List<Ticket>> CreateTickets(List<Ticket> tickets);
         Task<List<SeatLock>> GetLocksByOrderAndSeat(Guid orderToken, int seatId);
         Task<Presentation?> GetPresentationById(int presentationId);
-        Task UpdateSeatAvailability(List<int> seatIds, bool isAvailable);
+        Task UpdateSeatAvailability(List<int> seatIds, bool isAvailable, int presentationId);
+        Task InitializeSeatPresentations(int presentationId);
         Task CancelOrder(Guid orderToken);
         Task<List<SeatLock>> GetSeatLocksByOrderToken(Guid orderToken);
         Task<TicketOrder?> FindTicketOrderByOrderToken(Guid orderToken);
         Task<List<Ticket>> FindTicketsByOrderId(int orderId);
         Task<List<Ticket>> FindTicketsByPhoneBookingCode(string phoneBookingCode);
+        Task<List<SeatLock>> GetLocksByOrder(Guid orderToken);
+        Task<List<SeatLock>> GetLocksByOrder(string orderToken);
     }
 }

--- a/WebApi/Interfaces/Services/ITicketService.cs
+++ b/WebApi/Interfaces/Services/ITicketService.cs
@@ -16,5 +16,6 @@ namespace WebApi.Interfaces.Services
         Task CancelOrder(Guid orderToken);
         Task<byte[]> GetTicketsByOrderToken(Guid orderToken);
         Task<byte[]> GetTicketsByPhoneBookingCode(string phoneBookingCode);
+        Task UpdateSeatAvailability(List<int> seatIds, bool isAvailable, int presentationId);
     }
 }

--- a/WebApi/Migrations/20250322143924_AddAvailableSeatsToPresentation.Designer.cs
+++ b/WebApi/Migrations/20250322143924_AddAvailableSeatsToPresentation.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace WebApi.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250322143924_AddAvailableSeatsToPresentation")]
+    partial class AddAvailableSeatsToPresentation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -187,6 +190,9 @@ namespace WebApi.Migrations
                     b.Property<int>("HallId")
                         .HasColumnType("int");
 
+                    b.Property<bool>("IsAvailable")
+                        .HasColumnType("tinyint(1)");
+
                     b.Property<int>("RowNumber")
                         .HasColumnType("int");
 
@@ -232,37 +238,6 @@ namespace WebApi.Migrations
                     b.HasIndex("TicketOrderId");
 
                     b.ToTable("SeatLocks");
-                });
-
-            modelBuilder.Entity("WebApi.Models.SeatPresentation", b =>
-                {
-                    b.Property<int>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("int");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime(6)");
-
-                    b.Property<bool>("IsAvailable")
-                        .HasColumnType("tinyint(1)");
-
-                    b.Property<int>("PresentationId")
-                        .HasColumnType("int");
-
-                    b.Property<int>("SeatId")
-                        .HasColumnType("int");
-
-                    b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("datetime(6)");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("PresentationId");
-
-                    b.HasIndex("SeatId", "PresentationId")
-                        .IsUnique();
-
-                    b.ToTable("SeatPresentations");
                 });
 
             modelBuilder.Entity("WebApi.Models.Ticket", b =>
@@ -429,25 +404,6 @@ namespace WebApi.Migrations
                         .HasForeignKey("TicketOrderId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.Navigation("Seat");
-                });
-
-            modelBuilder.Entity("WebApi.Models.SeatPresentation", b =>
-                {
-                    b.HasOne("WebApi.Models.Presentation", "Presentation")
-                        .WithMany()
-                        .HasForeignKey("PresentationId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.HasOne("WebApi.Models.Seat", "Seat")
-                        .WithMany()
-                        .HasForeignKey("SeatId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Presentation");
 
                     b.Navigation("Seat");
                 });

--- a/WebApi/Migrations/20250322143924_AddAvailableSeatsToPresentation.cs
+++ b/WebApi/Migrations/20250322143924_AddAvailableSeatsToPresentation.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAvailableSeatsToPresentation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AvailableSeats",
+                table: "Presentations",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AvailableSeats",
+                table: "Presentations");
+        }
+    }
+}

--- a/WebApi/Migrations/20250322151221_AddSeatPresentationTable.Designer.cs
+++ b/WebApi/Migrations/20250322151221_AddSeatPresentationTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace WebApi.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250322151221_AddSeatPresentationTable")]
+    partial class AddSeatPresentationTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -186,6 +189,9 @@ namespace WebApi.Migrations
 
                     b.Property<int>("HallId")
                         .HasColumnType("int");
+
+                    b.Property<bool>("IsAvailable")
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<int>("RowNumber")
                         .HasColumnType("int");

--- a/WebApi/Migrations/20250322151221_AddSeatPresentationTable.cs
+++ b/WebApi/Migrations/20250322151221_AddSeatPresentationTable.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using MySql.EntityFrameworkCore.Metadata;
+
+#nullable disable
+
+namespace WebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSeatPresentationTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "SeatPresentations",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySQL:ValueGenerationStrategy", MySQLValueGenerationStrategy.IdentityColumn),
+                    SeatId = table.Column<int>(type: "int", nullable: false),
+                    PresentationId = table.Column<int>(type: "int", nullable: false),
+                    IsAvailable = table.Column<bool>(type: "tinyint(1)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_SeatPresentations", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_SeatPresentations_Presentations_PresentationId",
+                        column: x => x.PresentationId,
+                        principalTable: "Presentations",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_SeatPresentations_Seats_SeatId",
+                        column: x => x.SeatId,
+                        principalTable: "Seats",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                })
+                .Annotation("MySQL:Charset", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeatPresentations_PresentationId",
+                table: "SeatPresentations",
+                column: "PresentationId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_SeatPresentations_SeatId_PresentationId",
+                table: "SeatPresentations",
+                columns: new[] { "SeatId", "PresentationId" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "SeatPresentations");
+        }
+    }
+}

--- a/WebApi/Migrations/20250322151734_AddSeatPresentationModel.Designer.cs
+++ b/WebApi/Migrations/20250322151734_AddSeatPresentationModel.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace WebApi.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250322151734_AddSeatPresentationModel")]
+    partial class AddSeatPresentationModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/WebApi/Migrations/20250322151734_AddSeatPresentationModel.cs
+++ b/WebApi/Migrations/20250322151734_AddSeatPresentationModel.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace WebApi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSeatPresentationModel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsAvailable",
+                table: "Seats");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsAvailable",
+                table: "Seats",
+                type: "tinyint(1)",
+                nullable: false,
+                defaultValue: false);
+        }
+    }
+}

--- a/WebApi/Models/Exceptions/TicketNotFoundException.cs
+++ b/WebApi/Models/Exceptions/TicketNotFoundException.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace WebApi.Models.Exceptions
+{
+    public class TicketNotFoundException : Exception
+    {
+        public TicketNotFoundException() : base("The requested tickets could not be found.")
+        {
+        }
+
+        public TicketNotFoundException(string message) : base(message)
+        {
+        }
+
+        public TicketNotFoundException(string message, Exception innerException) 
+            : base(message, innerException)
+        {
+        }
+    }
+} 

--- a/WebApi/Models/Presentation.cs
+++ b/WebApi/Models/Presentation.cs
@@ -24,6 +24,8 @@ namespace WebApi.Models
         [StringLength(100)]
         public string HallName { get; set; } = "";
         
+        public int AvailableSeats { get; set; }
+        
         public required Movie Movie { get; set; }
         public required Hall Hall { get; set; }
         public ICollection<Ticket> Tickets { get; set; }

--- a/WebApi/Models/Seat.cs
+++ b/WebApi/Models/Seat.cs
@@ -11,7 +11,6 @@ namespace WebApi.Models
         public int HallId { get; set; }
         public int RowNumber { get; set; }
         public int SeatNumber { get; set; }
-        public bool IsAvailable { get; set; }
         public DateTime CreatedAt { get; set; }
 
         public required Hall Hall { get; set; }

--- a/WebApi/Models/SeatPresentation.cs
+++ b/WebApi/Models/SeatPresentation.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace WebApi.Models
+{
+    public class SeatPresentation
+    {
+        public int Id { get; set; }
+        public int SeatId { get; set; }
+        public int PresentationId { get; set; }
+        public bool IsAvailable { get; set; } = true;
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        // Navigation properties
+        public Seat? Seat { get; set; }
+        public Presentation? Presentation { get; set; }
+    }
+} 

--- a/WebApi/Repositories/TicketRepository.cs
+++ b/WebApi/Repositories/TicketRepository.cs
@@ -78,19 +78,31 @@ namespace WebApi.Repositories
                 return new List<Seat>();
             }
 
-            var bookedSeatIds = await _context.Tickets
-                .Where(t => t.PresentationId == presentationId &&
-                       t.Status != TicketStatus.Cancelled)
-                .Select(t => t.SeatId)
+            // Initialize SeatPresentations if they don't exist yet
+            bool hasExistingRecords = await _context.SeatPresentations
+                .AnyAsync(sp => sp.PresentationId == presentationId);
+                
+            if (!hasExistingRecords)
+            {
+                await InitializeSeatPresentations(presentationId);
+            }
+
+            // Get seat IDs that are unavailable from SeatPresentations
+            var unavailableSeatIds = await _context.SeatPresentations
+                .Where(sp => sp.PresentationId == presentationId && !sp.IsAvailable)
+                .Select(sp => sp.SeatId)
                 .ToListAsync();
 
+            // Get locked seats
             var lockedSeatIds = await _context.SeatLocks
-                .Where(l => l.ExpiresAt > DateTime.UtcNow)
+                .Where(l => l.PresentationId == presentationId && l.ExpiresAt > DateTime.UtcNow)
                 .Select(l => l.SeatId)
                 .ToListAsync();
 
-            var unavailableSeatIds = bookedSeatIds.Concat(lockedSeatIds).ToList();
+            // Combine all unavailable seat IDs
+            unavailableSeatIds = unavailableSeatIds.Concat(lockedSeatIds).Distinct().ToList();
 
+            // Get available seats
             var availableSeats = await _context.Seats
                 .Where(s => s.HallId == presentation.HallId &&
                        !unavailableSeatIds.Contains(s.Id))
@@ -108,44 +120,81 @@ namespace WebApi.Repositories
         {
             try
             {
-                // First, verify the seats belong to the correct hall
-                var presentation = await _context.Presentations
-                    .Include(p => p.Hall)
-                    .FirstOrDefaultAsync(p => p.Id == presentationId);
-
-                if (presentation == null)
+                // Initialize SeatPresentations if they don't exist yet
+                bool hasExistingRecords = await _context.SeatPresentations
+                    .AnyAsync(sp => sp.PresentationId == presentationId);
+                    
+                if (!hasExistingRecords)
                 {
-                    _logger.LogWarning("Presentation {PresentationId} not found", presentationId);
-                    return false;
+                    _logger.LogWarning("No SeatPresentation records found for presentation {PresentationId}. Initializing...", presentationId);
+                    await InitializeSeatPresentations(presentationId);
+                    
+                    // Double-check initialization was successful
+                    hasExistingRecords = await _context.SeatPresentations
+                        .AnyAsync(sp => sp.PresentationId == presentationId);
+                        
+                    if (!hasExistingRecords)
+                    {
+                        _logger.LogError("Failed to initialize SeatPresentation records for presentation {PresentationId}", presentationId);
+                        return false;
+                    }
                 }
 
-                // Get seats and verify they belong to the presentation's hall
-                var seats = await _context.Seats
-                    .Where(s => seatIds.Contains(s.Id))
+                // Get all requested seats to check their availability
+                var requestedSeatPresentations = await _context.SeatPresentations
+                    .Where(sp => sp.PresentationId == presentationId && 
+                           seatIds.Contains(sp.SeatId))
                     .ToListAsync();
-
-                var invalidSeats = seats.Where(s => s.HallId != presentation.HallId).ToList();
-                if (invalidSeats.Any())
+                    
+                if (requestedSeatPresentations.Count < seatIds.Count)
                 {
+                    var missingSeatIds = seatIds.Except(requestedSeatPresentations.Select(sp => sp.SeatId)).ToList();
                     _logger.LogWarning(
-                        "Seats {SeatIds} do not belong to hall {HallId} for presentation {PresentationId}",
-                        string.Join(", ", invalidSeats.Select(s => s.Id)),
-                        presentation.HallId,
+                        "Some requested seats {MissingSeatIds} have no SeatPresentation records for presentation {PresentationId}",
+                        string.Join(", ", missingSeatIds),
                         presentationId);
                     return false;
                 }
 
-                // Get booked seats (excluding cancelled tickets)
-                var bookedSeats = await _context.Tickets
-                    .Where(t => t.PresentationId == presentationId &&
-                           t.Status != TicketStatus.Cancelled)
-                    .Select(t => t.SeatId)
-                    .ToListAsync();
+                // If we have an order token, get the seats that are already locked by this order
+                var currentOrderSeats = new List<int>();
+                if (orderToken.HasValue)
+                {
+                    currentOrderSeats = await _context.SeatLocks
+                        .Where(l => l.OrderToken == orderToken.Value && 
+                                   l.PresentationId == presentationId && 
+                                   l.ExpiresAt > DateTime.UtcNow)
+                        .Select(l => l.SeatId)
+                        .ToListAsync();
+                    
+                    _logger.LogInformation(
+                        "Order {OrderToken} already has {LockCount} seats locked: {LockedSeats}",
+                        orderToken.Value,
+                        currentOrderSeats.Count,
+                        string.Join(", ", currentOrderSeats));
+                }
 
-                // Get locked seats - Only check locks from other orders
+                // Get unavailable seats from SeatPresentations, excluding seats already locked by this order
+                var unavailableSeats = requestedSeatPresentations
+                    .Where(sp => !sp.IsAvailable && 
+                                (orderToken == null || !currentOrderSeats.Contains(sp.SeatId)))
+                    .Select(sp => sp.SeatId)
+                    .ToList();
+
+                if (unavailableSeats.Any())
+                {
+                    _logger.LogWarning(
+                        "Seats {SeatIds} are not available for presentation {PresentationId} according to SeatPresentations",
+                        string.Join(", ", unavailableSeats),
+                        presentationId);
+                    return false;
+                }
+
+                // Check if any of the seats are locked by other orders
                 var lockedSeats = await _context.SeatLocks
                     .Where(l => l.ExpiresAt > DateTime.UtcNow &&
                            seatIds.Contains(l.SeatId) &&
+                           l.PresentationId == presentationId &&
                            (!orderToken.HasValue || l.OrderToken != orderToken.Value))
                     .Select(l => l.SeatId)
                     .ToListAsync();
@@ -159,35 +208,40 @@ namespace WebApi.Repositories
                     .SelectMany(o => o.Items.Select(i => i.SeatId))
                     .ToListAsync();
 
-                var unavailableSeats = new HashSet<int>();
-                unavailableSeats.UnionWith(bookedSeats);
-                unavailableSeats.UnionWith(lockedSeats);
-                unavailableSeats.UnionWith(pendingSeats);
+                // Check if any of the requested seats are locked or in pending orders
+                var unavailableDueToLocks = new HashSet<int>();
+                unavailableDueToLocks.UnionWith(lockedSeats);
+                unavailableDueToLocks.UnionWith(pendingSeats);
 
-                // Check if any of the requested seats are unavailable
-                var unavailableRequestedSeats = seatIds.Where(id => unavailableSeats.Contains(id)).ToList();
+                var unavailableRequestedSeats = seatIds.Where(id => unavailableDueToLocks.Contains(id)).ToList();
 
                 if (unavailableRequestedSeats.Any())
                 {
                     _logger.LogWarning(
                         "Seats {SeatIds} are not available for presentation {PresentationId}. " +
-                        "Booked: {BookedSeats}, Locked: {LockedSeats}, Pending: {PendingSeats}",
+                        "Locked: {LockedSeats}, Pending: {PendingSeats}",
                         string.Join(", ", unavailableRequestedSeats),
                         presentationId,
-                        string.Join(", ", bookedSeats),
                         string.Join(", ", lockedSeats),
                         string.Join(", ", pendingSeats));
                     return false;
                 }
 
+                _logger.LogInformation(
+                    "All seats {SeatIds} are available for presentation {PresentationId}",
+                    string.Join(", ", seatIds),
+                    presentationId);
+                    
                 return true;
             }
             catch (Exception ex)
             {
                 _logger.LogError(ex,
-                    "Error checking seat availability for presentation {PresentationId}",
-                    presentationId);
-                throw;
+                    "Error checking seat availability for presentation {PresentationId} with seats {SeatIds}",
+                    presentationId,
+                    string.Join(", ", seatIds));
+                // Return false instead of throwing to avoid crashing the application
+                return false;
             }
         }
 
@@ -289,9 +343,37 @@ namespace WebApi.Repositories
 
         public async Task<List<SeatLock>> GetLocksByOrder(Guid orderToken)
         {
-            return await _context.SeatLocks
-                .Where(l => l.OrderToken == orderToken)
-                .ToListAsync();
+            try
+            {
+                return await _context.SeatLocks
+                    .Where(l => l.OrderToken == orderToken)
+                    .ToListAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting locks by order token {OrderToken}", orderToken);
+                return new List<SeatLock>();
+            }
+        }
+
+        public async Task<List<SeatLock>> GetLocksByOrder(string orderToken)
+        {
+            try
+            {
+                // Parse the string orderToken to Guid
+                if (Guid.TryParse(orderToken, out Guid orderGuid))
+                {
+                    return await GetLocksByOrder(orderGuid);
+                }
+                
+                _logger.LogWarning("Failed to parse order token: {OrderToken}", orderToken);
+                return new List<SeatLock>();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error retrieving locks for order token: {OrderToken}", orderToken);
+                return new List<SeatLock>();
+            }
         }
 
         public async Task<Presentation?> GetPresentationById(int id)
@@ -302,14 +384,188 @@ namespace WebApi.Repositories
                 .FirstOrDefaultAsync(p => p.Id == id);
         }
 
-        public async Task UpdateSeatAvailability(List<int> seatIds, bool isAvailable)
+        public async Task UpdateSeatAvailability(List<int> seatIds, bool isAvailable, int presentationId)
         {
-            var seats = await _context.Seats.Where(s => seatIds.Contains(s.Id)).ToListAsync();
-            foreach (var seat in seats)
+            try
             {
-                seat.IsAvailable = isAvailable; // Update the seat availability
+                // Skip processing if no seat IDs are provided
+                if (seatIds == null || !seatIds.Any())
+                {
+                    _logger.LogWarning("No seat IDs provided for updating availability for presentation {PresentationId}", presentationId);
+                    return;
+                }
+
+                _logger.LogInformation(
+                    "Updating seat availability for presentation {PresentationId}, Setting {SeatsCount} seats to {IsAvailable}: {SeatIds}",
+                    presentationId, seatIds.Count, isAvailable ? "available" : "unavailable", string.Join(", ", seatIds));
+
+                // Get the presentation
+                var presentation = await _context.Presentations
+                    .Include(p => p.Hall)
+                    .FirstOrDefaultAsync(p => p.Id == presentationId);
+                
+                if (presentation == null || presentation.Hall == null)
+                {
+                    _logger.LogWarning("Presentation {PresentationId} or its Hall not found", presentationId);
+                    return;
+                }
+
+                // Get all the seats to make sure they exist
+                var seats = await _context.Seats
+                    .Where(s => seatIds.Contains(s.Id) && s.HallId == presentation.HallId)
+                    .ToListAsync();
+                    
+                if (seats.Count != seatIds.Count)
+                {
+                    var existingSeatIds = seats.Select(s => s.Id).ToList();
+                    var missingSeatIds = seatIds.Except(existingSeatIds).ToList();
+                    _logger.LogWarning(
+                        "Some seats {MissingSeatIds} don't exist or don't belong to hall {HallId}",
+                        string.Join(", ", missingSeatIds),
+                        presentation.HallId);
+                    
+                    // Continue with the valid seats
+                    seatIds = existingSeatIds;
+                }
+
+                // Track the actual number of seat availability changes
+                int availabilityChangesCount = 0;
+
+                // For each seat ID, update its availability
+                foreach (var seatId in seatIds)
+                {
+                    try
+                    {
+                        // Find or create the SeatPresentation record
+                        var seatPresentation = await _context.SeatPresentations
+                            .FirstOrDefaultAsync(sp => sp.SeatId == seatId && sp.PresentationId == presentationId);
+                        
+                        if (seatPresentation != null)
+                        {
+                            // Only update if the availability status is actually changing
+                            if (seatPresentation.IsAvailable != isAvailable)
+                            {
+                                // Update existing record
+                                bool oldStatus = seatPresentation.IsAvailable;
+                                seatPresentation.IsAvailable = isAvailable;
+                                seatPresentation.UpdatedAt = DateTime.UtcNow;
+                                
+                                _logger.LogDebug("Updated SeatPresentation for seat {SeatId}, presentation {PresentationId} from {OldStatus} to {NewStatus}",
+                                    seatId, presentationId, oldStatus, isAvailable);
+                                
+                                // Increment the change counter
+                                availabilityChangesCount++;
+                            }
+                            else
+                            {
+                                _logger.LogDebug("Skipped updating SeatPresentation for seat {SeatId}, already {Status}",
+                                    seatId, isAvailable ? "available" : "unavailable");
+                            }
+                        }
+                        else
+                        {
+                            // Create new record if it doesn't exist
+                            _context.SeatPresentations.Add(new SeatPresentation
+                            {
+                                SeatId = seatId,
+                                PresentationId = presentationId,
+                                IsAvailable = isAvailable,
+                                CreatedAt = DateTime.UtcNow,
+                                UpdatedAt = DateTime.UtcNow
+                            });
+                            
+                            _logger.LogDebug("Created new SeatPresentation for seat {SeatId}, presentation {PresentationId} with {IsAvailable}",
+                                seatId, presentationId, isAvailable);
+                            
+                            // If we're creating a new record and marking it as unavailable, count it as a change
+                            if (!isAvailable)
+                            {
+                                availabilityChangesCount++;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogError(ex, "Error updating SeatPresentation for seat {SeatId}, presentation {PresentationId}",
+                            seatId, presentationId);
+                        // Continue with the rest of the seats
+                    }
+                }
+                
+                // Apply changes first before recounting
+                await _context.SaveChangesAsync();
+                
+                // Calculate total seats in the hall
+                int totalSeats = presentation.Hall.Rows * presentation.Hall.SeatsPerRow;
+                
+                // Count unavailable seats for this presentation
+                int unavailableSeats = await _context.SeatPresentations
+                    .CountAsync(sp => sp.PresentationId == presentationId && !sp.IsAvailable);
+                
+                // Update available seats count on the presentation
+                int oldAvailableSeats = presentation.AvailableSeats;
+                presentation.AvailableSeats = totalSeats - unavailableSeats;
+                
+                _logger.LogInformation("Updating presentation {PresentationId} available seats from {OldAvailableSeats} to {NewAvailableSeats} (total: {TotalSeats}, unavailable: {UnavailableSeats}, changes: {ChangesCount})", 
+                    presentationId, oldAvailableSeats, presentation.AvailableSeats, totalSeats, unavailableSeats, availabilityChangesCount);
+                
+                // Save the updated presentation
+                await _context.SaveChangesAsync();
             }
-            await _context.SaveChangesAsync(); // Save changes to the database
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error updating seat availability for presentation {PresentationId} with seats {SeatIds}",
+                    presentationId, string.Join(", ", seatIds));
+            }
+        }
+        
+        public async Task InitializeSeatPresentations(int presentationId)
+        {
+            // Get the presentation with its hall
+            var presentation = await _context.Presentations
+                .Include(p => p.Hall)
+                .FirstOrDefaultAsync(p => p.Id == presentationId);
+                
+            if (presentation == null || presentation.Hall == null)
+            {
+                _logger.LogWarning("Cannot initialize seat presentations: Presentation {PresentationId} or its Hall not found", presentationId);
+                return;
+            }
+            
+            // Get all seats for this hall
+            var seats = await _context.Seats
+                .Where(s => s.HallId == presentation.HallId)
+                .ToListAsync();
+                
+            // Check if any SeatPresentation records already exist for this presentation
+            bool hasExistingRecords = await _context.SeatPresentations
+                .AnyAsync(sp => sp.PresentationId == presentationId);
+                
+            if (hasExistingRecords)
+            {
+                _logger.LogInformation("SeatPresentation records already exist for presentation {PresentationId}", presentationId);
+                return;
+            }
+            
+            // Create SeatPresentation records for each seat
+            var seatPresentations = seats.Select(seat => new SeatPresentation
+            {
+                SeatId = seat.Id,
+                PresentationId = presentationId,
+                IsAvailable = true,  // All seats are initially available
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            }).ToList();
+            
+            await _context.SeatPresentations.AddRangeAsync(seatPresentations);
+            
+            // Set the initial AvailableSeats count on the presentation
+            presentation.AvailableSeats = seats.Count;
+            
+            _logger.LogInformation("Initialized {Count} seats for presentation {PresentationId}", 
+                seats.Count, presentationId);
+                
+            await _context.SaveChangesAsync();
         }
 
         public async Task CancelOrder(Guid orderToken)
@@ -338,7 +594,7 @@ namespace WebApi.Repositories
             await SaveOrder(order);
 
             // Make seats available again
-            await UpdateSeatAvailability(seatIds.ToList(), true);
+            await UpdateSeatAvailability(seatIds.ToList(), true, order.PresentationId);
         }
 
         public async Task<List<SeatLock>> GetSeatLocksByOrderToken(Guid orderToken)
@@ -377,6 +633,20 @@ namespace WebApi.Repositories
                 .ThenInclude(p => p.Movie)
                 .Include(t => t.Seat)
                 .ToListAsync();
+        }
+
+        public async Task<Seat?> GetSeatById(int seatId)
+        {
+            try
+            {
+                return await _context.Seats
+                    .FirstOrDefaultAsync(s => s.Id == seatId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting seat by ID {SeatId}", seatId);
+                return null;
+            }
         }
     }
 }

--- a/WebApi/Services/TicketService.cs
+++ b/WebApi/Services/TicketService.cs
@@ -3,6 +3,7 @@ using WebApi.Exceptions;
 using WebApi.Interfaces.Repositories;
 using WebApi.Interfaces.Services;
 using WebApi.Models;
+using WebApi.Models.Exceptions;
 using WebApi.Models.Requests;
 using WebApi.Models.Responses;
 
@@ -80,7 +81,7 @@ namespace WebApi.Services
                 }
 
                 // After successfully locking the seats, update their availability
-                await _repository.UpdateSeatAvailability(new List<int> { selectedSeat.Id }, false);
+                await _repository.UpdateSeatAvailability(new List<int> { selectedSeat.Id }, false, request.PresentationId);
 
                 return new OrderResponse(order.OrderToken, new List<int> { selectedSeat.Id });
             }
@@ -95,65 +96,137 @@ namespace WebApi.Services
         {
             try
             {
+                _logger.LogInformation("Starting group order for presentation {PresentationId} with {NumberOfSeats} seats", 
+                    request.PresentationId, request.NumberOfSeats);
+                
                 if (request.NumberOfSeats <= 0 || request.NumberOfSeats > 20)
                 {
-                    throw new ArgumentException("Invalid number of seats requested");
+                    _logger.LogWarning("Invalid number of seats requested: {NumberOfSeats}", request.NumberOfSeats);
+                    throw new ArgumentException("Number of seats must be between 1 and 20");
                 }
 
-                var options = new Dictionary<string, SeatingOption>();
-                var orderToken = Guid.NewGuid();
+                // Get presentation
+                var presentation = await _repository.GetPresentationById(request.PresentationId);
+                if (presentation == null)
+                {
+                    _logger.LogWarning("Presentation {PresentationId} not found", request.PresentationId);
+                    throw new ArgumentException($"Presentation {request.PresentationId} not found");
+                }
 
-                // First try to find consecutive seats
+                // Initialize seat presentations if they don't exist yet
+                bool hasExistingRecords = await _context.SeatPresentations
+                    .AnyAsync(sp => sp.PresentationId == request.PresentationId);
+                    
+                if (!hasExistingRecords)
+                {
+                    _logger.LogWarning("No seat presentations found for presentation {PresentationId}, initializing them now", request.PresentationId);
+                    await _repository.InitializeSeatPresentations(request.PresentationId);
+                }
+
+                // Try to find consecutive seats first
                 var consecutiveSeats = await FindConsecutiveSeats(request.PresentationId, request.NumberOfSeats);
-                if (consecutiveSeats.Any())
+                
+                _logger.LogInformation("Found {SeatCount} consecutive seats for presentation {PresentationId}", 
+                    consecutiveSeats.Count, request.PresentationId);
+
+                // Options to offer to the user
+                var options = new Dictionary<string, SeatingOption>();
+
+                // If we have enough consecutive seats
+                if (consecutiveSeats.Count >= request.NumberOfSeats)
                 {
-                    var consecutiveGroups = await GetSplitArrangement(consecutiveSeats);
-                    options.Add("consecutive", new SeatingOption(
+                    // Select best consecutive seats
+                    var bestConsecutiveSeats = consecutiveSeats.Take(request.NumberOfSeats).ToList();
+                    
+                    // Get row grouping information
+                    var rows = await _repository.GetSeatsByIds(bestConsecutiveSeats);
+                    var rowGroups = rows
+                        .GroupBy(s => s.RowNumber)
+                        .Select(g => new RowGroup(
+                            g.Key, 
+                            g.Select(s => s.Id).ToList(),
+                            $"{g.Count()} seats in row {g.Key}" 
+                        ))
+                        .ToList();
+                        
+                    var option = new SeatingOption(
                         "Consecutive seats together",
-                        consecutiveSeats,
+                        bestConsecutiveSeats,
                         DateTime.UtcNow.AddMinutes(10),
-                        consecutiveGroups
-                    ));
+                        rowGroups
+                    );
+                    
+                    options["consecutive"] = option;
                 }
-
-                // Try consecutive seats with one less person if no exact match found
-                if (request.NumberOfSeats > 1 && !consecutiveSeats.Any())
+                else if (consecutiveSeats.Count >= request.NumberOfSeats - 1)
                 {
-                    var smallerConsecutive = await FindConsecutiveSeats(request.PresentationId, request.NumberOfSeats - 1);
-                    if (smallerConsecutive.Any())
-                    {
-                        var smallerGroups = await GetSplitArrangement(smallerConsecutive);
-                        options.Add("smaller_consecutive", new SeatingOption(
-                            $"Consecutive seats for {request.NumberOfSeats - 1} people",
-                            smallerConsecutive,
-                            DateTime.UtcNow.AddMinutes(10),
-                            smallerGroups
-                        ));
-                    }
+                    // Offer smaller consecutive group (one less seat)
+                    var smallerConsecutiveSeats = consecutiveSeats.Take(request.NumberOfSeats - 1).ToList();
+                    
+                    // Get row grouping information
+                    var rows = await _repository.GetSeatsByIds(smallerConsecutiveSeats);
+                    var rowGroups = rows
+                        .GroupBy(s => s.RowNumber)
+                        .Select(g => new RowGroup(
+                            g.Key, 
+                            g.Select(s => s.Id).ToList(),
+                            $"{g.Count()} seats in row {g.Key}" 
+                        ))
+                        .ToList();
+                        
+                    var option = new SeatingOption(
+                        $"{request.NumberOfSeats - 1} consecutive seats together",
+                        smallerConsecutiveSeats,
+                        DateTime.UtcNow.AddMinutes(10),
+                        rowGroups
+                    );
+                    
+                    options["smaller_consecutive"] = option;
                 }
 
-                // If no consecutive options, try split seating
-                if (!options.ContainsKey("consecutive"))
+                // If we don't have enough consecutive seats, try split seating
+                if (options.Count == 0)
                 {
                     var splitSeats = await FindBestSplitSeats(request.PresentationId, request.NumberOfSeats);
-                    if (splitSeats.Any())
+                    
+                    if (splitSeats.Count < request.NumberOfSeats)
                     {
-                        var splitGroups = await GetSplitArrangement(splitSeats);
-                        options.Add("split", new SeatingOption(
-                            "Split seating arrangement",
-                            splitSeats,
-                            DateTime.UtcNow.AddMinutes(10),
-                            splitGroups
-                        ));
+                        _logger.LogWarning("Not enough seats available for presentation {PresentationId} - requested {RequestedSeats}, found {FoundSeats}", 
+                            request.PresentationId, request.NumberOfSeats, splitSeats.Count);
+                        throw new NoSeatsAvailableException("Not enough available seats");
                     }
+                    
+                    // Get row grouping information
+                    var rows = await _repository.GetSeatsByIds(splitSeats);
+                    var rowGroups = rows
+                        .GroupBy(s => s.RowNumber)
+                        .Select(g => new RowGroup(
+                            g.Key, 
+                            g.Select(s => s.Id).ToList(),
+                            $"{g.Count()} seats in row {g.Key}" 
+                        ))
+                        .OrderBy(g => g.RowNumber)
+                        .ToList();
+                        
+                    var option = new SeatingOption(
+                        "Best available seats (split across rows)",
+                        splitSeats,
+                        DateTime.UtcNow.AddMinutes(10),
+                        rowGroups
+                    );
+                    
+                    options["split"] = option;
                 }
 
-                if (!options.Any())
+                if (options.Count == 0)
                 {
-                    throw new NoSeatsAvailableException("No seats available");
+                    _logger.LogWarning("No seating options found for presentation {PresentationId} with {NumberOfSeats} seats", 
+                        request.PresentationId, request.NumberOfSeats);
+                    throw new NoSeatsAvailableException("No available seating options");
                 }
 
-                // Create initial order without locking seats
+                // Create an order (initially without locking seats)
+                var orderToken = Guid.NewGuid();
                 var order = new TicketOrder
                 {
                     OrderToken = orderToken,
@@ -161,29 +234,75 @@ namespace WebApi.Services
                     CreatedAt = DateTime.UtcNow,
                     ExpiresAt = DateTime.UtcNow.AddMinutes(10),
                     Status = OrderStatus.Pending,
-                    AvailableOptions = options,
-                    RequestedSeats = request.NumberOfSeats // Store the original requested number of seats
+                    RequestedSeats = request.NumberOfSeats,
+                    AvailableOptions = options
                 };
+                
+                _logger.LogInformation("Creating initial order {OrderToken} for presentation {PresentationId} with options: {Options}", 
+                    orderToken, request.PresentationId, string.Join(", ", options.Keys));
 
-                if (!await _repository.SaveOrder(order))
+                // Save the order
+                var savedOrder = await _repository.SaveOrder(order);
+                if (!savedOrder)
                 {
+                    _logger.LogError("Failed to save order {OrderToken}", orderToken);
                     throw new Exception("Failed to save order");
                 }
 
-                // After successfully locking the seats, update their availability
-                await _repository.UpdateSeatAvailability(options.Values.SelectMany(o => o.SeatIds).ToList(), false);
-
-                return new GroupOrderResponse
+                // Get the seat IDs from the first available option
+                var initialSeatIds = options.Values.FirstOrDefault()?.SeatIds ?? new List<int>();
+                
+                if (initialSeatIds.Any())
                 {
-                    OrderToken = orderToken,
-                    HasConsecutiveSeats = options.ContainsKey("consecutive"),
-                    AvailableOptions = options,
-                    SeatIds = options.Values.FirstOrDefault()?.SeatIds ?? new List<int>()
+                    // Create locks for the selected seats
+                    var locks = initialSeatIds.Select(seatId => new SeatLock
+                    {
+                        SeatId = seatId,
+                        OrderToken = orderToken,
+                        PresentationId = request.PresentationId, // Make sure this matches the order's presentation ID
+                        TicketOrderId = order.Id,
+                        CreatedAt = DateTime.UtcNow,
+                        ExpiresAt = DateTime.UtcNow.AddMinutes(10)
+                    }).ToList();
+                    
+                    var addedLocks = await _repository.AddSeatLocks(locks);
+                    
+                    _logger.LogInformation("Created {LockCount} locks for order {OrderToken} presentation {PresentationId}", 
+                        locks.Count, orderToken, request.PresentationId);
+                    
+                    if (!addedLocks)
+                    {
+                        _logger.LogError("Failed to create locks for order {OrderToken}", orderToken);
+                    }
+                    
+                    // Update seat availability for the initially locked seats
+                    _logger.LogInformation("Marking {SeatCount} initial seats as unavailable for presentation {PresentationId}", 
+                        initialSeatIds.Count, request.PresentationId);
+                    await _repository.UpdateSeatAvailability(initialSeatIds, false, request.PresentationId);
+                }
+                
+                // Construct the response with the proper constructor that sets HasConsecutiveSeats
+                var response = new GroupOrderResponse(
+                    orderToken, 
+                    initialSeatIds,
+                    options.ContainsKey("consecutive")
+                )
+                {
+                    AvailableOptions = options
                 };
+
+                _logger.LogInformation("Returning group order response with token {OrderToken} and {OptionCount} options", 
+                    orderToken, options.Count);
+                return response;
+            }
+            catch (NoSeatsAvailableException)
+            {
+                throw;
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error starting group order");
+                _logger.LogError(ex, "Error starting group order for presentation {PresentationId}, seats: {NumberOfSeats}: {ErrorMessage}",
+                    request.PresentationId, request.NumberOfSeats, ex.Message);
                 throw;
             }
         }
@@ -192,14 +311,21 @@ namespace WebApi.Services
         {
             try
             {
+                _logger.LogInformation("Selecting option {Option} for order {OrderToken}", option, request.OrderToken);
+                
                 var order = await _repository.GetOrderByToken(request.OrderToken);
                 if (order == null || order.Status != OrderStatus.Pending)
                 {
+                    _logger.LogWarning("Order {OrderToken} not found or expired", request.OrderToken);
                     throw new OrderNotFoundException("Order not found or expired");
                 }
 
+                _logger.LogInformation("Found order {OrderToken} for presentation {PresentationId}", 
+                    request.OrderToken, order.PresentationId);
+
                 if (!order.AvailableOptions.TryGetValue(option, out var seatingOption))
                 {
+                    _logger.LogWarning("Invalid seating option {Option} for order {OrderToken}", option, request.OrderToken);
                     throw new ArgumentException("Invalid seating option");
                 }
 
@@ -209,6 +335,8 @@ namespace WebApi.Services
                     // This option is valid as long as it provides the advertised number of seats
                     if (seatingOption.SeatIds.Count != order.RequestedSeats - 1)
                     {
+                        _logger.LogWarning("Selected option {Option} provides {SeatCount} seats, but expected {ExpectedSeatCount} seats", 
+                            option, seatingOption.SeatIds.Count, order.RequestedSeats - 1);
                         throw new ArgumentException($"Selected option provides {seatingOption.SeatIds.Count} seats, but expected {order.RequestedSeats - 1} seats");
                     }
                 }
@@ -217,110 +345,280 @@ namespace WebApi.Services
                     // For all other options, verify we get the full number of requested seats
                     if (seatingOption.SeatIds.Count != order.RequestedSeats)
                     {
+                        _logger.LogWarning("Selected option {Option} provides {SeatCount} seats, but {RequestedSeatCount} were requested", 
+                            option, seatingOption.SeatIds.Count, order.RequestedSeats);
                         throw new ArgumentException($"Selected option provides {seatingOption.SeatIds.Count} seats, but {order.RequestedSeats} were requested");
                     }
                 }
 
-                // Get all currently locked seats for this order
-                var existingLocks = await _repository.GetSeatLocksByOrderToken(order.OrderToken);
+                // Get existing locks for this order
+                _logger.LogInformation("Retrieving existing locks for order {OrderToken}", request.OrderToken);
+                var existingLocks = await _repository.GetLocksByOrder(request.OrderToken);
+                _logger.LogInformation("Found {Count} existing locks for order", existingLocks.Count);
 
                 // Find seats that were locked but not selected in the chosen option
                 var seatsToUnlock = existingLocks
                     .Where(l => !seatingOption.SeatIds.Contains(l.SeatId))
                     .ToList();
 
+                _logger.LogInformation("Unlocking {UnlockCount} unselected seats for order {OrderToken}: {SeatIds}", 
+                    seatsToUnlock.Count, request.OrderToken, 
+                    seatsToUnlock.Any() ? string.Join(", ", seatsToUnlock.Select(l => l.SeatId)) : "none");
+
                 // Remove locks for unselected seats
                 if (seatsToUnlock.Any())
                 {
                     await _repository.RemoveSeatLocks(seatsToUnlock);
                     // Make unselected seats available again
-                    await _repository.UpdateSeatAvailability(seatsToUnlock.Select(l => l.SeatId).ToList(), true);
+                    _logger.LogInformation("Making {Count} unselected seats available again", seatsToUnlock.Count);
+                    await _repository.UpdateSeatAvailability(seatsToUnlock.Select(l => l.SeatId).ToList(), true, order.PresentationId);
+                }
+
+                // Get the currently locked seat IDs (without the ones we just unlocked)
+                var lockedSeatIds = existingLocks
+                    .Where(l => !seatsToUnlock.Contains(l))
+                    .Select(l => l.SeatId)
+                    .ToList();
+
+                // Find seats that need a lock
+                var seatsNeedingLocks = seatingOption.SeatIds
+                    .Where(seatId => !lockedSeatIds.Contains(seatId))
+                    .ToList();
+                
+                if (seatsNeedingLocks.Any())
+                {
+                    _logger.LogInformation("Creating new locks for {LockCount} seats for order {OrderToken}: {SeatIds}", 
+                        seatsNeedingLocks.Count, request.OrderToken, string.Join(", ", seatsNeedingLocks));
+                    
+                    var newLocks = seatsNeedingLocks.Select(seatId => new SeatLock
+                    {
+                        SeatId = seatId,
+                        OrderToken = order.OrderToken,
+                        PresentationId = order.PresentationId,
+                        TicketOrderId = order.Id,
+                        CreatedAt = DateTime.UtcNow,
+                        ExpiresAt = DateTime.UtcNow.AddMinutes(10)
+                    }).ToList();
+                    
+                    var added = await _repository.AddSeatLocks(newLocks);
+                    if (!added)
+                    {
+                        _logger.LogError("Failed to create locks for seats {SeatIds}", 
+                            string.Join(", ", seatsNeedingLocks));
+                    }
                 }
 
                 // Verify seats are still available (excluding our own remaining locks)
                 if (!await _repository.AreSeatAvailable(order.PresentationId, seatingOption.SeatIds, order.OrderToken))
                 {
+                    _logger.LogError("Selected seats {SeatIds} are no longer available for order {OrderToken}, presentation {PresentationId}", 
+                        string.Join(", ", seatingOption.SeatIds), request.OrderToken, order.PresentationId);
                     throw new SeatNotAvailableException("Selected seats are no longer available");
                 }
 
-                // Update order with selected seats
-                order.Items = seatingOption.SeatIds.Select(seatId => new TicketOrderItem
+                // Update order with selected seats and clear any existing items first
+                order.Items = new List<TicketOrderItem>();
+                foreach (var seatId in seatingOption.SeatIds)
                 {
-                    SeatId = seatId,
-                    CreatedAt = DateTime.UtcNow
-                }).ToList();
+                    order.Items.Add(new TicketOrderItem
+                    {
+                        SeatId = seatId,
+                        CreatedAt = DateTime.UtcNow
+                    });
+                }
+
+                _logger.LogInformation("Updating order {OrderToken} with {SeatCount} selected seats: {SeatIds}", 
+                    request.OrderToken, seatingOption.SeatIds.Count, string.Join(", ", seatingOption.SeatIds));
 
                 if (!await _repository.SaveOrder(order))
                 {
+                    _logger.LogError("Failed to save order {OrderToken}", request.OrderToken);
                     throw new Exception("Failed to save order");
                 }
 
                 // After successfully updating the order, update seat availability for selected seats
-                await _repository.UpdateSeatAvailability(seatingOption.SeatIds, false);
+                _logger.LogInformation("Marking {SeatCount} selected seats as unavailable for presentation {PresentationId}", 
+                    seatingOption.SeatIds.Count, order.PresentationId);
+                await _repository.UpdateSeatAvailability(seatingOption.SeatIds, false, order.PresentationId);
+                
+                _logger.LogInformation("Successfully selected option {Option} for order {OrderToken} with {SeatCount} seats: {SeatIds}", 
+                    option, request.OrderToken, seatingOption.SeatIds.Count, string.Join(", ", seatingOption.SeatIds));
 
                 return new OrderResponse(order.OrderToken, seatingOption.SeatIds);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error selecting seating option");
+                _logger.LogError(ex, "Error selecting seating option: {ErrorMessage}", ex.Message);
                 throw;
             }
         }
 
         public async Task<List<TicketResponse>> ConfirmOrder(Guid orderToken, ConfirmOrderRequest request)
         {
-            var order = await _repository.GetOrderByToken(orderToken, true);
-            if (order == null || order.Status != OrderStatus.Pending)
+            try 
             {
-                throw new OrderNotFoundException("Order not found or expired");
+                _logger.LogInformation("Starting to confirm order {OrderToken}", orderToken);
+                
+                var order = await _repository.GetOrderByToken(orderToken, true);
+                if (order == null || order.Status != OrderStatus.Pending)
+                {
+                    _logger.LogWarning("Order {OrderToken} not found or expired", orderToken);
+                    throw new OrderNotFoundException("Order not found or expired");
+                }
+
+                // Get the seat IDs from the order items
+                var seatIds = order.Items.Select(i => i.SeatId).ToList();
+                
+                if (seatIds.Count == 0)
+                {
+                    _logger.LogWarning("Order {OrderToken} has no seats selected", orderToken);
+                    throw new ArgumentException("No seats selected");
+                }
+                
+                _logger.LogInformation("Confirming order {OrderToken} for presentation {PresentationId} with {SeatCount} seats: {SeatIds}", 
+                    orderToken, order.PresentationId, seatIds.Count, string.Join(", ", seatIds));
+
+                // Get the presentation to make sure it exists
+                var presentation = await _repository.GetPresentationById(order.PresentationId);
+                if (presentation == null)
+                {
+                    _logger.LogWarning("Presentation {PresentationId} not found for order {OrderToken}", 
+                        order.PresentationId, orderToken);
+                    throw new Exception($"Presentation {order.PresentationId} not found");
+                }
+
+                // Get all existing locks for this order
+                _logger.LogInformation("Retrieving existing locks for order {OrderToken}", orderToken.ToString());
+                var existingLocks = await _repository.GetLocksByOrder(orderToken.ToString());
+                _logger.LogInformation("Found {Count} existing locks for order", existingLocks.Count);
+
+                // Check if any seats don't have locks and create them if needed
+                var seatsNeedingLocks = new List<int>();
+                foreach (var seatId in seatIds)
+                {
+                    if (!existingLocks.Any(l => l.SeatId == seatId))
+                    {
+                        _logger.LogWarning("Seat {SeatId} is not locked for order {OrderToken} - will create lock", 
+                            seatId, orderToken);
+                        seatsNeedingLocks.Add(seatId);
+                    }
+                }
+                
+                // Create locks for any seats that don't have them
+                if (seatsNeedingLocks.Any())
+                {
+                    var newLocks = seatsNeedingLocks.Select(seatId => new SeatLock
+                    {
+                        SeatId = seatId,
+                        OrderToken = orderToken,
+                        PresentationId = order.PresentationId,
+                        TicketOrderId = order.Id,
+                        CreatedAt = DateTime.UtcNow,
+                        ExpiresAt = DateTime.UtcNow.AddMinutes(10)
+                    }).ToList();
+                    
+                    var added = await _repository.AddSeatLocks(newLocks);
+                    if (!added)
+                    {
+                        _logger.LogError("Failed to create locks for seats {SeatIds} for order {OrderToken}", 
+                            string.Join(", ", seatsNeedingLocks), orderToken);
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Created {LockCount} new locks for order {OrderToken}", 
+                            newLocks.Count, orderToken);
+                    }
+                }
+
+                // Verify seats are still available (excluding our own locks)
+                if (!await _repository.AreSeatAvailable(order.PresentationId, seatIds, orderToken))
+                {
+                    _logger.LogError("Seats {SeatIds} are no longer available for order {OrderToken}, presentation {PresentationId}", 
+                        string.Join(", ", seatIds), orderToken, order.PresentationId);
+                    throw new SeatNotAvailableException("Some selected seats are no longer available");
+                }
+
+                // Update order status
+                order.Status = OrderStatus.Confirmed;
+                var saved = await _repository.SaveOrder(order);
+                if (!saved)
+                {
+                    _logger.LogError("Failed to update order status to Confirmed for order {OrderToken}", orderToken);
+                    throw new Exception("Failed to update order status");
+                }
+
+                // Create tickets for the order
+                var tickets = new List<Ticket>();
+                
+                foreach (var item in order.Items)
+                {
+                    // Get the seat and presentation entities for this ticket
+                    var seat = await _repository.GetSeatById(item.SeatId);
+                    var ticketPresentation = await _repository.GetPresentationById(order.PresentationId);
+                    
+                    if (seat != null && ticketPresentation != null)
+                    {
+                        var ticket = new Ticket
+                        {
+                            PresentationId = order.PresentationId,
+                            SeatId = item.SeatId,
+                            TicketOrderId = order.Id,
+                            CustomerName = request.CustomerName,
+                            CustomerEmail = request.CustomerEmail,
+                            Status = TicketStatus.Reserved,
+                            PurchaseDate = DateTime.UtcNow,
+                            CreatedAt = DateTime.UtcNow,
+                            UpdatedAt = DateTime.UtcNow,
+                            Presentation = ticketPresentation,
+                            Seat = seat,
+                            TicketOrder = order
+                        };
+                        
+                        tickets.Add(ticket);
+                    }
+                }
+
+                // Create the tickets
+                var createdTickets = await _repository.CreateTickets(tickets);
+                
+                _logger.LogInformation("Successfully confirmed order {OrderToken} with {TicketCount} tickets", 
+                    orderToken.ToString(), createdTickets.Count);
+
+                // Now, fetch the full ticket information including navigation properties for the response
+                var fullTickets = new List<TicketResponse>();
+                foreach (var ticket in createdTickets)
+                {
+                    // Load related entities for each ticket
+                    var ticketPresentation = await _repository.GetPresentationById(ticket.PresentationId);
+                    var seat = await _repository.GetSeatById(ticket.SeatId);
+                    
+                    if (ticketPresentation != null && seat != null)
+                    {
+                        fullTickets.Add(new TicketResponse(
+                            ticket.Id,
+                            ticketPresentation.Movie?.Title ?? "Unknown Movie",
+                            ticketPresentation.HallName,
+                            ticketPresentation.StartTime,
+                            ticketPresentation.EndTime,
+                            seat.RowNumber,
+                            seat.SeatNumber,
+                            ticket.CustomerName,
+                            ticket.CustomerEmail,
+                            ticket.Status,
+                            ticket.PurchaseDate
+                        ));
+                    }
+                }
+
+                _logger.LogInformation("Returning {TicketCount} ticket details for order {OrderToken}", 
+                    fullTickets.Count, orderToken);
+                return fullTickets;
             }
-
-            // Get the seat IDs from the order items
-            var seatIds = order.Items.Select(i => i.SeatId).ToList();
-
-            // Verify seats are still available (excluding our own locks)
-            if (!await _repository.AreSeatAvailable(order.PresentationId, seatIds, orderToken))
+            catch (Exception ex)
             {
-                throw new SeatNotAvailableException("Some selected seats are no longer available");
+                _logger.LogError(ex, "Error confirming order {OrderToken}: {ErrorMessage}", orderToken, ex.Message);
+                throw;
             }
-
-            // Create tickets for the order
-            var tickets = order.Items.Select(item => new Ticket
-            {
-                PresentationId = order.PresentationId,
-                SeatId = item.SeatId,
-                TicketOrderId = order.Id,
-                CustomerName = request.CustomerName,
-                CustomerEmail = request.CustomerEmail,
-                Status = TicketStatus.Reserved,
-                PurchaseDate = DateTime.UtcNow,
-                CreatedAt = DateTime.UtcNow,
-                UpdatedAt = DateTime.UtcNow,
-                Presentation = order.Presentation!,
-                Seat = item.Seat,
-                TicketOrder = order
-            }).ToList();
-
-            // Update order status
-            order.Status = OrderStatus.Confirmed;
-            await _repository.SaveOrder(order);
-
-            // Create the tickets
-            var createdTickets = await _repository.CreateTickets(tickets);
-
-            return createdTickets.Select(t => new TicketResponse(
-                t.Id,
-                t.Presentation.Movie.Title,
-                t.Presentation.Hall.Name,
-                t.Presentation.StartTime,
-                t.Presentation.EndTime,
-                t.Seat.RowNumber,
-                t.Seat.SeatNumber,
-                t.CustomerName,
-                t.CustomerEmail,
-                t.Status,
-                t.PurchaseDate
-            )).ToList();
         }
 
         public async Task<OrderResponse> AddSeatsToOrder(Guid orderToken, AddSeatsRequest request)
@@ -378,7 +676,7 @@ namespace WebApi.Services
                     throw new Exception("Failed to save order");
                 }
 
-                await _repository.UpdateSeatAvailability(request.SeatIds, false);
+                await _repository.UpdateSeatAvailability(request.SeatIds, false, order.PresentationId);
 
                 return new OrderResponse(orderToken, order.Items.Select(i => i.SeatId).ToList());
             }
@@ -408,9 +706,13 @@ namespace WebApi.Services
                 // Remove seat from order
                 order.Items.Remove(itemToRemove);
 
-                // Get and remove seat locks through repository
-                var locks = await _repository.GetExpiredLocks();
-                var seatLocks = locks.Where(l => l.OrderToken == orderToken && l.SeatId == seatId).ToList();
+                // Get and remove seat locks for this specific seat
+                var locks = await _repository.GetLocksByOrder(orderToken); 
+                var seatLocks = locks.Where(l => l.SeatId == seatId).ToList();
+                
+                _logger.LogInformation("Removing {LockCount} locks for seat {SeatId} from order {OrderToken}", 
+                    seatLocks.Count, seatId, orderToken);
+                    
                 await _repository.RemoveSeatLocks(seatLocks);
 
                 if (!await _repository.SaveOrder(order))
@@ -418,14 +720,16 @@ namespace WebApi.Services
                     throw new Exception("Failed to save order");
                 }
 
-                // After successfully removing the seat, update its availability
-                await _repository.UpdateSeatAvailability(new List<int> { seatId }, true);
+                // After successfully removing the seat, update its availability to available (true)
+                _logger.LogInformation("Marking seat {SeatId} as available for presentation {PresentationId}", 
+                    seatId, order.PresentationId);
+                await _repository.UpdateSeatAvailability(new List<int> { seatId }, true, order.PresentationId);
 
                 return new OrderResponse(order.OrderToken, order.Items.Select(i => i.SeatId).ToList());
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error removing seat from order");
+                _logger.LogError(ex, "Error removing seat from order: {ErrorMessage}", ex.Message);
                 throw;
             }
         }
@@ -645,13 +949,17 @@ namespace WebApi.Services
         public async Task<byte[]> GetTicketsByPhoneBookingCode(string phoneBookingCode)
         {
             var tickets = await _repository.FindTicketsByPhoneBookingCode(phoneBookingCode);
-
-            if(tickets.Count() == 0 || tickets == null)
+            if (!tickets.Any())
             {
-                throw new OrderNotFoundException("No tickets found with the given phone booking code.");
+                throw new TicketNotFoundException($"No tickets found with phone booking code {phoneBookingCode}");
             }
-
+            
             return _ticketPdfService.CreatePdfTicketsAsByteArray(tickets, Guid.NewGuid());
+        }
+
+        public async Task UpdateSeatAvailability(List<int> seatIds, bool isAvailable, int presentationId)
+        {
+            await _repository.UpdateSeatAvailability(seatIds, isAvailable, presentationId);
         }
     }
 }


### PR DESCRIPTION
# [FD4-13] Als bioscoopbezoeker wil ik weten welke film wanneer in welke zaal draait zodat ik bewust een film kan kiezen

## Toegevoegde Functies

- **Implementatie Filmagenda Pagina**: 
  - Uitgebreide filmschema weergave met dagelijkse navigatie gemaakt (URL: /schedule)
  - Format- en sorteerfilters toegevoegd voor verbeterde gebruikerservaring
  - Responsief ontwerp geïmplementeerd voor mobiele en desktop weergave

- **Uitverkocht Functionaliteit**:
  - `IsSoldOut` eigenschap toegevoegd aan `ShowtimeItem` model
  - Niet-klikbare UI geïmplementeerd voor uitverkochte voorstellingen
  - Visuele indicatoren verbeterd met doorgestreepte tekst en uitgeschakelde cursor

- **Format Filtering Systeem**:
  - Consistente tracking van format beschikbaarheid over dagselecties toegevoegd
  - Intelligente "(geen op deze dag)" indicatoren geïmplementeerd voor niet-beschikbare formats
  - Alle formatopties in dropdown behouden ongeacht huidige selectie

- **Backend Verbeteringen**:
  - `SeatPresentation` entiteit gecreëerd om stoelbeschikbaarheid per voorstelling nauwkeurig bij te houden
  - Toegang tot presentatiegegevens geoptimaliseerd met juiste entiteitsrelaties
  - Migratiescripts toegevoegd voor database schema-updates

- **Test Tools**:
  - `AlmostSoldOutTest` pagina geïmplementeerd voor eenvoudig testen van drempelscenario's (URL: /almost-sold-out-test)
  - API-eindpunten gecreëerd voor het testen van uitverkochte en bijna-uitverkochte toestanden

Deze PR voltooit de implementatie van de filmagenda met uitgebreide filteropties en nauwkeurige beschikbaarheidsindicatoren, wat de ervaring bij het boeken van films aanzienlijk verbetert.